### PR TITLE
feature/F-05.1-Conexion-PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ DB_DATABASE=laravel
 DB_USERNAME=sail
 DB_PASSWORD=password
 
+# DB usuario dedicado del panel (permisos mínimos)
+DB_PANEL_USERNAME=panel_user
+DB_PANEL_PASSWORD=
+
 SESSION_DRIVER=database
 SESSION_LIFETIME=120
 SESSION_ENCRYPT=false

--- a/config/database.php
+++ b/config/database.php
@@ -113,6 +113,22 @@ return [
             // 'trust_server_certificate' => env('DB_TRUST_SERVER_CERTIFICATE', 'false'),
         ],
 
+        'panel' => [
+            'driver'         => 'pgsql',
+            'url'            => env('DB_URL'),
+            'host'           => env('DB_HOST', '127.0.0.1'),
+            'port'           => env('DB_PORT', '5432'),
+            'database'       => env('DB_DATABASE', 'laravel'),
+            'username'       => env('DB_PANEL_USERNAME', ''),
+            'password'       => env('DB_PANEL_PASSWORD', ''),
+            'charset'        => env('DB_CHARSET', 'utf8'),
+            'prefix'         => '',
+            'prefix_indexes' => true,
+            'search_path'    => 'public',
+            'sslmode'        => env('DB_SSLMODE', 'prefer'),
+        ],
+
+
     ],
 
     /*

--- a/database/sql/setup_panel_user.sql
+++ b/database/sql/setup_panel_user.sql
@@ -4,7 +4,7 @@ CREATE USER panel_user WITH PASSWORD 'your_secure_password';
 -- logs: solo lectura (gestionada por n8n)
 GRANT SELECT ON logs TO panel_user;
 
--- applications: solo lectura
+-- applications: solo lectura?
 GRANT SELECT ON applications TO panel_user;
 
 -- archived_logs: lectura/escritura, sin DELETE por diseño (Escenario 2)
@@ -24,10 +24,6 @@ GRANT USAGE, SELECT ON SEQUENCE archived_logs_id_seq TO panel_user;
 GRANT USAGE, SELECT ON SEQUENCE comments_id_seq TO panel_user;
 GRANT USAGE, SELECT ON SEQUENCE error_codes_id_seq TO panel_user;
 GRANT USAGE, SELECT ON SEQUENCE users_id_seq TO panel_user;
-
--- error_code_comments: lectura/escritura (requisito técnico F-00.2)
-GRANT SELECT, INSERT, UPDATE ON error_code_comments TO panel_user;
-GRANT USAGE, SELECT ON SEQUENCE error_code_comments_id_seq TO panel_user;
 
 
 -- NOTA F-04.9 (COULD): si se implementa borrar histórico, añadir:

--- a/database/sql/setup_panel_user.sql
+++ b/database/sql/setup_panel_user.sql
@@ -1,0 +1,34 @@
+-- Ejecutar como superusuario (sail/postgres)
+CREATE USER panel_user WITH PASSWORD 'your_secure_password';
+
+-- logs: solo lectura (gestionada por n8n)
+GRANT SELECT ON logs TO panel_user;
+
+-- applications: solo lectura
+GRANT SELECT ON applications TO panel_user;
+
+-- archived_logs: lectura/escritura, sin DELETE por diseño (Escenario 2)
+GRANT SELECT, INSERT, UPDATE ON archived_logs TO panel_user;
+
+-- comments: lectura/escritura (polimórfica: cubre archived_logs y error_codes)
+GRANT SELECT, INSERT, UPDATE ON comments TO panel_user;
+
+-- error_codes: lectura/escritura
+GRANT SELECT, INSERT, UPDATE ON error_codes TO panel_user;
+
+-- users: lectura e inserción
+GRANT SELECT, INSERT ON users TO panel_user;
+
+-- Sequences necesarias para INSERT
+GRANT USAGE, SELECT ON SEQUENCE archived_logs_id_seq TO panel_user;
+GRANT USAGE, SELECT ON SEQUENCE comments_id_seq TO panel_user;
+GRANT USAGE, SELECT ON SEQUENCE error_codes_id_seq TO panel_user;
+GRANT USAGE, SELECT ON SEQUENCE users_id_seq TO panel_user;
+
+-- error_code_comments: lectura/escritura (requisito técnico F-00.2)
+GRANT SELECT, INSERT, UPDATE ON error_code_comments TO panel_user;
+GRANT USAGE, SELECT ON SEQUENCE error_code_comments_id_seq TO panel_user;
+
+
+-- NOTA F-04.9 (COULD): si se implementa borrar histórico, añadir:
+-- GRANT DELETE ON archived_logs TO panel_user;

--- a/tests/Feature/DatabaseConnectionTest.php
+++ b/tests/Feature/DatabaseConnectionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DatabaseConnectionTest extends TestCase
+{
+    /**
+     * Escenario 1: Conexión exitosa a PostgreSQL.
+     */
+    public function test_can_connect_to_postgresql(): void
+    {
+        $result = DB::select('SELECT 1 AS connected');
+
+        $this->assertEquals(1, $result[0]->connected);
+    }
+
+    /**
+     * Escenario 2: El usuario del panel no puede hacer DELETE en archived_logs.
+     * Requiere que el usuario 'panel_user' esté creado en la BD.
+     */
+    #[\PHPUnit\Framework\Attributes\Group('integration')]
+    public function test_panel_user_cannot_delete_archived_logs(): void
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        DB::connection('panel')->statement('DELETE FROM archived_logs WHERE id = 0');
+    }
+
+    /**
+     * Escenario 3: Las credenciales no están en archivos versionados.
+     */
+    public function test_env_file_is_not_committed(): void
+    {
+        $this->assertFileDoesNotExist(base_path('.env.backup'));
+        $this->assertStringContainsString('.env', file_get_contents(base_path('.gitignore')));
+    }
+}


### PR DESCRIPTION
This pull request introduces a dedicated database user for the panel with restricted permissions, configures a new PostgreSQL connection for this user, and adds integration tests to ensure proper access controls and environment file handling. The changes are grouped into environment configuration, database setup, and testing.

**Environment and Configuration**

* Added `DB_PANEL_USERNAME` and `DB_PANEL_PASSWORD` to `.env.example` for specifying the panel user's credentials.
* Configured a new `panel` PostgreSQL connection in `config/database.php` using the dedicated credentials and connection parameters.

**Database Setup**

* Created `database/sql/setup_panel_user.sql` to define the `panel_user` with minimal permissions, granting only the necessary access to specific tables and sequences, and explicitly restricting DELETE operations on `archived_logs`.

**Testing**

* Added `tests/Feature/DatabaseConnectionTest.php` with integration tests to verify PostgreSQL connectivity, enforce restricted DELETE permissions for `panel_user`, and ensure environment credential files are not committed to version control.