### PR TITLE
Feature/f 05.5 users mock sesion

### DIFF
--- a/app/Http/Middleware/AuthMock.php
+++ b/app/Http/Middleware/AuthMock.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Support\Facades\Auth;
 
-class MockAuthUser
+class AuthMock
 {
     /**
      * Handle an incoming request.
@@ -16,8 +16,8 @@ class MockAuthUser
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (!Auth::check() && env('AUTH_MOCK_USER_ID')) {
-            Auth::loginUsingId(env('AUTH_MOCK_USER_ID'));
+        if (!Auth::check()) {
+            Auth::loginUsingId((int) env('AUTH_MOCK_USER_ID', 1));
         }
 
         return $next($request);

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Comment;
+use App\Models\User;
+
+class CommentPolicy
+{
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Comment $comment): bool
+    {
+        return $user->id === $comment->user_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Comment;
+use App\Policies\CommentPolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+   
+    protected $policies = [
+        Comment::class => CommentPolicy::class,
+    ];
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        $this->registerPolicies();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,7 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-use App\Http\Middleware\MockAuthUser;
+use App\Http\Middleware\AuthMock;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -12,9 +12,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->alias([
-            'mock.auth' => MockAuthUser::class,
-        ]);
+        if (env('APP_ENV') !== 'production') {
+            $middleware->alias([
+                'auth.mock' => AuthMock::class,
+            ]);
+        }
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
 ];

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -12,6 +12,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
+            /* TODO: external_id deberia ser unique() no? */
             $table->string('external_id')->nullable();
             $table->timestamps();
         });

--- a/database/seeders/ApplicationSeeder.php
+++ b/database/seeders/ApplicationSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Application;
+
+class ApplicationSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Application::updateOrCreate(
+            ['id' => 1],
+            [
+                'name'        => 'Application 1',
+                'description' => 'Description 1',
+            ]
+        );
+    }
+}

--- a/database/seeders/CommentSeeder.php
+++ b/database/seeders/CommentSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Comment;
+use App\Models\ErrorCode;
+
+class CommentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Comment::updateOrCreate(
+            ['id' => 1],
+            [
+                'content' => 'Comment 1 de Admin',
+                'user_id' => 1,
+                'commentable_type' => ErrorCode::class,
+                'commentable_id' => 1,
+            ]
+        );
+
+        Comment::updateOrCreate(
+            ['id' => 2],
+            [
+                'content' => 'Comment 2 de User',
+                'user_id' => 2,
+                'commentable_type' => ErrorCode::class,
+                'commentable_id' => 1,
+            ]
+        );
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -15,11 +14,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            UserSeeder::class,
+            ApplicationSeeder::class,
+            ErrorCodeSeeder::class,
+            CommentSeeder::class,
         ]);
     }
 }

--- a/database/seeders/ErrorCodeSeeder.php
+++ b/database/seeders/ErrorCodeSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\ErrorCode;
+
+class ErrorCodeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        ErrorCode::updateOrCreate(
+            ['id' => 1],
+            [
+                'code'        => 'ERR-001',
+                'application_id' => 1,
+                'name'        => 'Error Code 1',
+                'description' => 'Description 1',
+                'severity'    => 'low',
+            ]
+        );
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        User::updateOrCreate(
+            ['id' => 1],
+            [
+                'name'        => 'Admin',
+                'email'       => 'admin@example.com',
+                'external_id' => 'admin-mock',
+            ]
+        );
+
+        User::updateOrCreate(
+            ['id' => 2],
+            [
+                'name'        => 'User 2',
+                'email'       => 'user2@example.com',
+                'external_id' => 'user-mock',
+            ]
+        );
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,13 +3,15 @@
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Auth;
 use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use App\Models\Comment;
 
 Route::get('/', function () {
     return view('welcome');
 });
 
 /* Rutas protegidas por el middleware MockAuthUser */
-Route::middleware('mock.auth')->group(function () {
+Route::middleware('auth.mock')->group(function () {
     /* TODDO: Rutas directas a las vistas porque no hay controladores para probar el componente Layout */
     Route::view('/dashboard', 'dashboard')->name('dashboard');
     Route::view('/logs', 'logs.index')->name('logs.index');
@@ -20,3 +22,12 @@ Route::middleware('mock.auth')->group(function () {
 Route::post('/logout', function () {
     return redirect()->route('dashboard')->with('status', 'Sesión cerrada');
 })->name('logout');
+
+
+/* TODO: Ruta después de probar la policy para comprobar que funciona */
+Route::get('/test-comment-update', function () {
+    $comment = Comment::findOrFail(2);
+    Gate::authorize('update', $comment);
+    
+    return 'Puedes editar este comentario';
+});


### PR DESCRIPTION
Dado que aun no están hechas las vistas de index/show de comments ni los controladores, una forma de comprobar que todo es correcto es añadir en **routes/web.php**

use App\Models\Comment;
use Illuminate\Support\Facades\Gate;
use Illuminate\Support\Facades\Route;

Route::get('/test-comment-update', function () {
    $comment = Comment::findOrFail(1);
    Gate::authorize('update', $comment);
    
    return 'Puedes editar este comentario';
});


Dado que el comentario ha sido generado por el usuario "autenticado", debe permitirlo. 

Para comprobar que devuelve un `403` cuando el usuario no está autorizado para ello cambia en **routes/web.php** que busque el comentario con id 2:

$comment = Comment::findOrFail(2);
    

