### PR TITLE
Feature/f 01.1 dashboard cards

### DIFF
--- a/app/Enums/Severity.php
+++ b/app/Enums/Severity.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+enum Severity: string
+{
+    case CRITICAL = 'critical';
+    case HIGH = 'high';
+    case MEDIUM = 'medium';
+    case LOW = 'low';
+    case OTHER = 'other';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(
+            static fn (self $severity): string => $severity->value,
+            self::cases()
+        );
+    }
+
+    public static function validationRule(): string
+    {
+        return 'in:' . implode(',', self::values());
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\DashboardIndexRequest;
 use App\Services\Contracts\LogServiceInterface;
 use Illuminate\Contracts\View\View;
 
@@ -9,9 +10,11 @@ class DashboardController extends Controller
 {
     public function __construct(private LogServiceInterface $logService) {}
 
-    public function index(): View
+    public function index(DashboardIndexRequest $request): View
     {
-        $cards = collect($this->logService->dashboardSeverityCards())
+        $includeArchived = $request->boolean('include_archived', false);
+
+        $cards = collect($this->logService->dashboardSeverityCards($includeArchived))
             ->map(fn (array $card): array => [
                 ...$card,
                 'title' => __('severity.' . $card['key']),
@@ -21,6 +24,7 @@ class DashboardController extends Controller
 
         return view('dashboard', [
             'cards' => $cards,
+            'includeArchived' => $includeArchived,
             'unresolvedLabel' => __('logs.filters.resolved_unresolved'),
             'resolvedLabel' => __('logs.filters.resolved_resolved'),
         ]);

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -14,7 +14,7 @@ class DashboardController extends Controller
         $cards = collect($this->logService->dashboardSeverityCards())
             ->map(fn (array $card): array => [
                 ...$card,
-                'title' => __('dashboard.cards.' . $card['key']),
+                'title' => __('severity.' . $card['key']),
                 'href' => route('logs.index', $card['routeParams']),
             ])
             ->all();

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -11,8 +11,18 @@ class DashboardController extends Controller
 
     public function index(): View
     {
+        $cards = collect($this->logService->dashboardSeverityCards())
+            ->map(fn (array $card): array => [
+                ...$card,
+                'title' => __('dashboard.cards.' . $card['key']),
+                'href' => route('logs.index', $card['routeParams']),
+            ])
+            ->all();
+
         return view('dashboard', [
-            'severityCounts' => $this->logService->severityCounts(),
+            'cards' => $cards,
+            'unresolvedLabel' => __('logs.filters.resolved_unresolved'),
+            'resolvedLabel' => __('logs.filters.resolved_resolved'),
         ]);
     }
 }

--- a/app/Http/Requests/ArchivedLogIndexRequest.php
+++ b/app/Http/Requests/ArchivedLogIndexRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\Severity;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ArchivedLogIndexRequest extends FormRequest
@@ -17,7 +18,7 @@ class ArchivedLogIndexRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'severity' => ['nullable', 'in:critical,high,medium,low,other'],
+            'severity' => ['nullable', Severity::validationRule()],
             'tutorial' => ['nullable', 'in:with_tutorial,without_tutorial'],
         ];
     }

--- a/app/Http/Requests/DashboardIndexRequest.php
+++ b/app/Http/Requests/DashboardIndexRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DashboardIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'include_archived' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/ErrorCodeIndexRequest.php
+++ b/app/Http/Requests/ErrorCodeIndexRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\Severity;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ErrorCodeIndexRequest extends FormRequest
@@ -17,7 +18,7 @@ class ErrorCodeIndexRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'severity' => ['nullable', 'in:critical,high,medium,low,other'],
+            'severity' => ['nullable', Severity::validationRule()],
         ];
     }
 }

--- a/app/Livewire/LogsTable.php
+++ b/app/Livewire/LogsTable.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use App\Enums\Severity;
 use App\Services\Contracts\LogServiceInterface;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
@@ -21,6 +22,22 @@ class LogsTable extends Component
     public ?string $severity = null;
     public ?string $archived = null;
     public ?string $resolved = null;
+
+    public function mount(): void
+    {
+        $querySeverity = request()->query('severity');
+
+        if (!is_string($querySeverity) || $querySeverity === '') {
+            return;
+        }
+
+        if (!in_array($querySeverity, Severity::values(), true)) {
+            return;
+        }
+
+        $this->severityInput = $querySeverity;
+        $this->severity = $querySeverity;
+    }
 
     public function resetFilters(): void
     {
@@ -53,7 +70,7 @@ class LogsTable extends Component
 
         $validated = $this->validate([
             'searchInput' => ['nullable', 'string', 'max:255'],
-            'severityInput' => ['nullable', 'in:critical,high,medium,low,other'],
+            'severityInput' => ['nullable', Severity::validationRule()],
             'archivedInput' => ['nullable', 'in:archived,not_archived'],
             'resolvedInput' => ['nullable', 'in:resolved,unresolved'],
         ]);

--- a/app/Repositories/Contracts/LogRepositoryInterface.php
+++ b/app/Repositories/Contracts/LogRepositoryInterface.php
@@ -29,11 +29,11 @@ interface LogRepositoryInterface
     ): LengthAwarePaginator;
 
     /**
-     * Counts grouped by severity, incluyendo zeros (solo logs activos).
+     * Counts grouped by severity y resolved (todos los logs).
      *
-     * @return array<string,int>
+     * @return array<string,array{resolved:int,unresolved:int,total:int}>
      */
-    public function severityCounts(): array;
+    public function severityResolvedCounts(): array;
 
     /**
      * Devuelve el id de ArchivedLog asociado al log (matched_archived_log_id) o null si no está archivado.

--- a/app/Repositories/Contracts/LogRepositoryInterface.php
+++ b/app/Repositories/Contracts/LogRepositoryInterface.php
@@ -29,11 +29,11 @@ interface LogRepositoryInterface
     ): LengthAwarePaginator;
 
     /**
-     * Counts grouped by severity y resolved (todos los logs).
+     * Counts grouped by severity y resolved.
      *
      * @return array<string,array{resolved:int,unresolved:int,total:int}>
      */
-    public function severityResolvedCounts(): array;
+    public function severityResolvedCounts(bool $includeArchived = false): array;
 
     /**
      * Devuelve el id de ArchivedLog asociado al log (matched_archived_log_id) o null si no está archivado.

--- a/app/Repositories/Eloquent/LogRepository.php
+++ b/app/Repositories/Eloquent/LogRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories\Eloquent;
 
+use App\Enums\Severity;
 use App\Models\Log;
 use App\Repositories\Contracts\LogRepositoryInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -66,7 +67,7 @@ class LogRepository implements LogRepositoryInterface
 
     public function severityResolvedCounts(): array
     {
-        $severities = ['critical', 'high', 'medium', 'low', 'other'];
+        $severities = Severity::values();
 
         $rows = Log::query()
             ->selectRaw('severity, resolved, count(*) as count')

--- a/app/Repositories/Eloquent/LogRepository.php
+++ b/app/Repositories/Eloquent/LogRepository.php
@@ -64,20 +64,36 @@ class LogRepository implements LogRepositoryInterface
             ->paginate($perPage);
     }
 
-    public function severityCounts(): array
+    public function severityResolvedCounts(): array
     {
         $severities = ['critical', 'high', 'medium', 'low', 'other'];
 
-        $counts = Log::query()
-            ->whereNull('matched_archived_log_id')
-            ->selectRaw('severity, count(*) as count')
+        $rows = Log::query()
+            ->selectRaw('severity, resolved, count(*) as count')
             ->whereIn('severity', $severities)
-            ->groupBy('severity')
-            ->pluck('count', 'severity');
+            ->groupBy('severity', 'resolved')
+            ->get();
 
         $result = [];
         foreach ($severities as $severity) {
-            $result[$severity] = (int) ($counts[$severity] ?? 0);
+            $result[$severity] = [
+                'resolved' => 0,
+                'unresolved' => 0,
+                'total' => 0,
+            ];
+        }
+
+        foreach ($rows as $row) {
+            $severity = (string) $row->severity;
+            $count = (int) $row->count;
+            $bucket = (bool) $row->resolved ? 'resolved' : 'unresolved';
+
+            if (!isset($result[$severity])) {
+                continue;
+            }
+
+            $result[$severity][$bucket] += $count;
+            $result[$severity]['total'] += $count;
         }
 
         return $result;

--- a/app/Repositories/Eloquent/LogRepository.php
+++ b/app/Repositories/Eloquent/LogRepository.php
@@ -65,11 +65,12 @@ class LogRepository implements LogRepositoryInterface
             ->paginate($perPage);
     }
 
-    public function severityResolvedCounts(): array
+    public function severityResolvedCounts(bool $includeArchived = false): array
     {
         $severities = Severity::values();
 
         $rows = Log::query()
+            ->when(!$includeArchived, fn ($q) => $q->whereNull('matched_archived_log_id'))
             ->selectRaw('severity, resolved, count(*) as count')
             ->whereIn('severity', $severities)
             ->groupBy('severity', 'resolved')

--- a/app/Services/Contracts/LogServiceInterface.php
+++ b/app/Services/Contracts/LogServiceInterface.php
@@ -28,11 +28,11 @@ interface LogServiceInterface
     ): LengthAwarePaginator;
 
     /**
-     * Counts grouped by severity, incluyendo zeros (solo logs activos).
+     * Data de cards del dashboard con estado resolved/unresolved.
      *
-     * @return array<string,int>
+     * @return array<int,array{key:string,count:int,resolvedCount:int,unresolvedCount:int,routeParams:array<string,string>}>
      */
-    public function severityCounts(): array;
+    public function dashboardSeverityCards(): array;
 
     /**
      * Devuelve el id de ArchivedLog asociado al log o null si no está archivado.

--- a/app/Services/Contracts/LogServiceInterface.php
+++ b/app/Services/Contracts/LogServiceInterface.php
@@ -32,7 +32,7 @@ interface LogServiceInterface
      *
      * @return array<int,array{key:string,count:int,resolvedCount:int,unresolvedCount:int,routeParams:array<string,string>}>
      */
-    public function dashboardSeverityCards(): array;
+    public function dashboardSeverityCards(bool $includeArchived = false): array;
 
     /**
      * Devuelve el id de ArchivedLog asociado al log o null si no está archivado.

--- a/app/Services/LogService.php
+++ b/app/Services/LogService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\Severity;
 use App\Models\Log;
 use App\Repositories\Contracts\LogRepositoryInterface;
 use App\Services\Contracts\LogServiceInterface;
@@ -46,7 +47,7 @@ class LogService implements LogServiceInterface
 
     public function dashboardSeverityCards(): array
     {
-        $severityKeys = ['critical', 'high', 'medium', 'low', 'other'];
+        $severityKeys = Severity::values();
         $bySeverity = $this->logRepository->severityResolvedCounts();
 
         $cards = collect($severityKeys)

--- a/app/Services/LogService.php
+++ b/app/Services/LogService.php
@@ -45,13 +45,13 @@ class LogService implements LogServiceInterface
         return $this->logRepository->searchAndFilter($search, $severity, $archived, $resolved, $perPage);
     }
 
-    public function dashboardSeverityCards(): array
+    public function dashboardSeverityCards(bool $includeArchived = false): array
     {
         $severityKeys = Severity::values();
-        $bySeverity = $this->logRepository->severityResolvedCounts();
+        $bySeverity = $this->logRepository->severityResolvedCounts($includeArchived);
 
         $cards = collect($severityKeys)
-            ->map(function (string $key) use ($bySeverity): array {
+            ->map(function (string $key) use ($bySeverity, $includeArchived): array {
                 $resolvedCount = (int) ($bySeverity[$key]['resolved'] ?? 0);
                 $unresolvedCount = (int) ($bySeverity[$key]['unresolved'] ?? 0);
 
@@ -60,7 +60,9 @@ class LogService implements LogServiceInterface
                     'count' => $resolvedCount + $unresolvedCount,
                     'resolvedCount' => $resolvedCount,
                     'unresolvedCount' => $unresolvedCount,
-                    'routeParams' => ['severity' => $key],
+                    'routeParams' => $includeArchived
+                        ? ['severity' => $key]
+                        : ['severity' => $key, 'archived' => 'not_archived'],
                 ];
             })
             ->values();

--- a/app/Services/LogService.php
+++ b/app/Services/LogService.php
@@ -44,9 +44,38 @@ class LogService implements LogServiceInterface
         return $this->logRepository->searchAndFilter($search, $severity, $archived, $resolved, $perPage);
     }
 
-    public function severityCounts(): array
+    public function dashboardSeverityCards(): array
     {
-        return $this->logRepository->severityCounts();
+        $severityKeys = ['critical', 'high', 'medium', 'low', 'other'];
+        $bySeverity = $this->logRepository->severityResolvedCounts();
+
+        $cards = collect($severityKeys)
+            ->map(function (string $key) use ($bySeverity): array {
+                $resolvedCount = (int) ($bySeverity[$key]['resolved'] ?? 0);
+                $unresolvedCount = (int) ($bySeverity[$key]['unresolved'] ?? 0);
+
+                return [
+                    'key' => $key,
+                    'count' => $resolvedCount + $unresolvedCount,
+                    'resolvedCount' => $resolvedCount,
+                    'unresolvedCount' => $unresolvedCount,
+                    'routeParams' => ['severity' => $key],
+                ];
+            })
+            ->values();
+
+        $allResolved = (int) $cards->sum('resolvedCount');
+        $allUnresolved = (int) $cards->sum('unresolvedCount');
+
+        $cards->prepend([
+            'key' => 'all',
+            'count' => $allResolved + $allUnresolved,
+            'resolvedCount' => $allResolved,
+            'unresolvedCount' => $allUnresolved,
+            'routeParams' => [],
+        ]);
+
+        return $cards->all();
     }
 
     public function archivedLogIdFor(int $logId): ?int

--- a/app/View/Components/DashboardCard.php
+++ b/app/View/Components/DashboardCard.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class DashboardCard extends Component
+{
+    public string $backgroundClass;
+    public string $accentTextClass;
+    public string $borderClass;
+
+    public function __construct(
+        public string $title,
+        public string $href,
+        public int $unresolvedCount,
+        public int $resolvedCount,
+        public string $unresolvedLabel,
+        public string $resolvedLabel,
+        public string $severityKey = 'all'
+    ) {
+        [$this->backgroundClass, $this->accentTextClass, $this->borderClass] = match ($this->severityKey) {
+            'critical' => ['bg-rose-100 dark:bg-rose-700/35', 'text-rose-900 dark:text-rose-100', 'border-rose-200 dark:border-rose-500/40'],
+            'high' => ['bg-orange-100 dark:bg-orange-700/35', 'text-orange-900 dark:text-orange-100', 'border-orange-200 dark:border-orange-500/40'],
+            'medium' => ['bg-yellow-100 dark:bg-yellow-600/35', 'text-yellow-900 dark:text-yellow-100', 'border-yellow-200 dark:border-yellow-400/40'],
+            'low' => ['bg-emerald-100 dark:bg-emerald-700/35', 'text-emerald-900 dark:text-emerald-100', 'border-emerald-200 dark:border-emerald-500/40'],
+            'other' => ['bg-slate-100 dark:bg-slate-700/45', 'text-slate-800 dark:text-slate-100', 'border-slate-200 dark:border-slate-500/40'],
+            default => ['bg-[#ede7ef] dark:bg-[#5b3853]/45', 'text-[#5b3853] dark:text-[#f7eaf2]', 'border-[#d9c8df] dark:border-[#8f6f87]/50'],
+        };
+    }
+
+    public function render(): View|Closure|string
+    {
+        return view('components.dashboard-card');
+    }
+}

--- a/database/data/mock-logs.php
+++ b/database/data/mock-logs.php
@@ -1,0 +1,30 @@
+<?php
+
+$severities = ['critical', 'high', 'low', 'other'];
+$rows = [];
+$id = 1;
+$baseDate = new DateTimeImmutable('now');
+
+foreach ($severities as $severity) {
+    for ($i = 1; $i <= 10; $i++) {
+        $rows[] = [
+            'id' => $id++,
+            'application_id' => 1,
+            'error_code_id' => 1,
+            'severity' => $severity,
+            'message' => sprintf('Seed: %s log #%02d', $severity, $i),
+            'file' => sprintf('seed/%s.log', $severity),
+            'line' => 100 + $i,
+            'metadata' => [
+                'seed' => true,
+                'source' => 'mock-logs.php',
+                'batch' => 'dashboard-cards',
+            ],
+            'matched_archived_log_id' => $i % 4 === 0 ? 1 : null,
+            'resolved' => $i % 2 === 0,
+            'created_at' => $baseDate->modify('-' . (($id - 1) * 3) . ' minutes')->format('Y-m-d H:i:s'),
+        ];
+    }
+}
+
+return $rows;

--- a/database/seeders/LogSeeder.php
+++ b/database/seeders/LogSeeder.php
@@ -4,89 +4,20 @@ namespace Database\Seeders;
 
 use App\Models\Log;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class LogSeeder extends Seeder
 {
     public function run(): void
     {
-        Log::updateOrCreate(
-            ['id' => 1],
-            [
-                'application_id' => 1,
-                'error_code_id' => 1,
-                'severity' => 'low',
-                'message' => 'Seed: log de prueba',
-                'file' => 'seed.log',
-                'line' => 10,
-                'metadata' => ['seed' => true, 'source' => 'LogSeeder'],
-                'matched_archived_log_id' => 1,
-                'resolved' => true,
-                'created_at' => now(),
-            ]
-        );
+        $mockLogs = require database_path('data/mock-logs.php');
 
-        Log::updateOrCreate(
-            ['id' => 2],
-            [
-                'application_id' => 1,
-                'error_code_id' => 1,
-                'severity' => 'medium',
-                'message' => 'Seed: log de prueba',
-                'file' => 'seed.log',
-                'line' => 10,
-                'metadata' => ['seed' => true, 'source' => 'LogSeeder'],
-                'matched_archived_log_id' => null,
-                'resolved' => false,
-                'created_at' => now(),
-            ]
-        );
+        foreach ($mockLogs as $log) {
+            Log::create($log);
+        }
 
-        Log::updateOrCreate(
-            ['id' => 3],
-            [
-                'application_id' => 1,
-                'error_code_id' => 1,
-                'severity' => 'high',
-                'message' => 'Seed: log de prueba',
-                'file' => 'seed.log',
-                'line' => 10,
-                'metadata' => ['seed' => true, 'source' => 'LogSeeder'],
-                'matched_archived_log_id' => null,
-                'resolved' => true,
-                'created_at' => now(),
-            ]
-        );
-
-        Log::updateOrCreate(
-            ['id' => 4],
-            [
-                'application_id' => 1,
-                'error_code_id' => 1,
-                'severity' => 'critical',
-                'message' => 'Seed: log de prueba',
-                'file' => 'seed.log',
-                'line' => 10,
-                'metadata' => ['seed' => true, 'source' => 'LogSeeder'],
-                'matched_archived_log_id' => 2,
-                'resolved' => false,
-                'created_at' => now(),
-            ]
-        );
-
-        Log::updateOrCreate(
-            ['id' => 5],
-            [
-                'application_id' => 1,
-                'error_code_id' => 1,
-                'severity' => 'other',
-                'message' => 'Seed: log de prueba',
-                'file' => 'seed.log',
-                'line' => 10,
-                'metadata' => ['seed' => true, 'source' => 'LogSeeder'],
-                'matched_archived_log_id' => null,
-                'resolved' => false,
-                'created_at' => now(),
-            ]
+        DB::statement(
+            "SELECT setval(pg_get_serial_sequence('logs', 'id'), (SELECT COALESCE(MAX(id), 1) FROM logs))"
         );
     }
 }

--- a/lang/en/archived_logs.php
+++ b/lang/en/archived_logs.php
@@ -19,12 +19,6 @@ return [
 
     'filters' => [
         'severity' => 'Severity',
-        'severity_all' => 'All',
-        'severity_critical' => 'Critical',
-        'severity_high' => 'High',
-        'severity_medium' => 'Medium',
-        'severity_low' => 'Low',
-        'severity_other' => 'Other',
         'tutorial' => 'Tutorial',
         'tutorial_all' => 'All',
         'tutorial_with' => 'With tutorial',

--- a/lang/en/dashboard.php
+++ b/lang/en/dashboard.php
@@ -5,4 +5,7 @@ return [
     'title' => 'Dashboard',
     'welcome' => 'Welcome to the dashboard',
     'count' => 'Count',
+    'filters' => [
+        'include_archived' => 'Include archived',
+    ],
 ];

--- a/lang/en/error_codes.php
+++ b/lang/en/error_codes.php
@@ -22,11 +22,5 @@ return [
 
     'filters' => [
         'severity' => 'Severity',
-        'severity_all' => 'All',
-        'severity_critical' => 'Critical',
-        'severity_high' => 'High',
-        'severity_medium' => 'Medium',
-        'severity_low' => 'Low',
-        'severity_other' => 'Other',
     ],
 ];

--- a/lang/en/logs.php
+++ b/lang/en/logs.php
@@ -28,12 +28,6 @@ return [
         'search' => 'Search',
         'search_placeholder' => 'e.g. error message',
         'severity' => 'Severity',
-        'severity_all' => 'All',
-        'severity_critical' => 'Critical',
-        'severity_high' => 'High',
-        'severity_medium' => 'Medium',
-        'severity_low' => 'Low',
-        'severity_other' => 'Other',
 
         'archived' => 'Archived',
         'archived_all' => 'All',

--- a/lang/en/severity.php
+++ b/lang/en/severity.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'all' => 'All',
+    'critical' => 'Critical',
+    'high' => 'High',
+    'medium' => 'Medium',
+    'low' => 'Low',
+    'other' => 'Other',
+];

--- a/lang/es/archived_logs.php
+++ b/lang/es/archived_logs.php
@@ -19,12 +19,6 @@ return [
 
     'filters' => [
         'severity' => 'Severidad',
-        'severity_all' => 'Todas',
-        'severity_critical' => 'Crítica',
-        'severity_high' => 'Alta',
-        'severity_medium' => 'Media',
-        'severity_low' => 'Baja',
-        'severity_other' => 'Otra',
         'tutorial' => 'Tutorial',
         'tutorial_all' => 'Todos',
         'tutorial_with' => 'Con tutorial',

--- a/lang/es/dashboard.php
+++ b/lang/es/dashboard.php
@@ -5,4 +5,7 @@ return [
     'title' => 'Panel de logs',
     'welcome' => 'Bienvenido al panel de logs',
     'count' => 'Cantidad',
+    'filters' => [
+        'include_archived' => 'Incluir archivados',
+    ],
 ];

--- a/lang/es/error_codes.php
+++ b/lang/es/error_codes.php
@@ -22,11 +22,5 @@ return [
 
     'filters' => [
         'severity' => 'Severidad',
-        'severity_all' => 'Todas',
-        'severity_critical' => 'Crítica',
-        'severity_high' => 'Alta',
-        'severity_medium' => 'Media',
-        'severity_low' => 'Baja',
-        'severity_other' => 'Otra',
     ],
 ];

--- a/lang/es/logs.php
+++ b/lang/es/logs.php
@@ -28,12 +28,6 @@ return [
         'search' => 'Buscar',
         'search_placeholder' => 'p.ej. mensaje del error',
         'severity' => 'Severidad',
-        'severity_all' => 'Todas',
-        'severity_critical' => 'Crítica',
-        'severity_high' => 'Alta',
-        'severity_medium' => 'Media',
-        'severity_low' => 'Baja',
-        'severity_other' => 'Otra',
 
         'archived' => 'Archivado',
         'archived_all' => 'Todos',

--- a/lang/es/severity.php
+++ b/lang/es/severity.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'all' => 'Todos',
+    'critical' => 'Crítica',
+    'high' => 'Alta',
+    'medium' => 'Media',
+    'low' => 'Baja',
+    'other' => 'Otra',
+];

--- a/lang/va/archived_logs.php
+++ b/lang/va/archived_logs.php
@@ -19,12 +19,6 @@ return [
 
     'filters' => [
         'severity' => 'Severitat',
-        'severity_all' => 'Totes',
-        'severity_critical' => 'Crítica',
-        'severity_high' => 'Alta',
-        'severity_medium' => 'Mitjana',
-        'severity_low' => 'Baixa',
-        'severity_other' => 'Altra',
         'tutorial' => 'Tutorial',
         'tutorial_all' => 'Tots',
         'tutorial_with' => 'Amb tutorial',

--- a/lang/va/dashboard.php
+++ b/lang/va/dashboard.php
@@ -5,4 +5,7 @@ return [
     'title' => 'Panell de logs',
     'welcome' => 'Benvingut al panell de logs',
     'count' => 'Quantitat',
+    'filters' => [
+        'include_archived' => 'Incloure arxivats',
+    ],
 ];

--- a/lang/va/error_codes.php
+++ b/lang/va/error_codes.php
@@ -22,11 +22,5 @@ return [
 
     'filters' => [
         'severity' => 'Severitat',
-        'severity_all' => 'Totes',
-        'severity_critical' => 'Crítica',
-        'severity_high' => 'Alta',
-        'severity_medium' => 'Mitjana',
-        'severity_low' => 'Baixa',
-        'severity_other' => 'Altra',
     ],
 ];

--- a/lang/va/logs.php
+++ b/lang/va/logs.php
@@ -28,12 +28,6 @@ return [
         'search' => 'Cercar',
         'search_placeholder' => "p. ex. missatge de l'error",
         'severity' => 'Severitat',
-        'severity_all' => 'Totes',
-        'severity_critical' => 'Crítica',
-        'severity_high' => 'Alta',
-        'severity_medium' => 'Mitjana',
-        'severity_low' => 'Baixa',
-        'severity_other' => 'Altra',
 
         'archived' => 'Arxivat',
         'archived_all' => 'Tots',

--- a/lang/va/severity.php
+++ b/lang/va/severity.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'all' => 'Tots',
+    'critical' => 'Crítica',
+    'high' => 'Alta',
+    'medium' => 'Mitjana',
+    'low' => 'Baixa',
+    'other' => 'Altra',
+];

--- a/resources/views/archived-logs/index.blade.php
+++ b/resources/views/archived-logs/index.blade.php
@@ -11,12 +11,12 @@
                     name="severity"
                     class="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-base shadow-sm focus:border-[#5b3853] focus:outline-none focus:ring-2 focus:ring-[#5b3853]/20"
                 >
-                    <option value="">{{ __('archived_logs.filters.severity_all') }}</option>
-                    <option value="critical" @selected(($severity ?? null) === 'critical')>{{ __('archived_logs.filters.severity_critical') }}</option>
-                    <option value="high" @selected(($severity ?? null) === 'high')>{{ __('archived_logs.filters.severity_high') }}</option>
-                    <option value="medium" @selected(($severity ?? null) === 'medium')>{{ __('archived_logs.filters.severity_medium') }}</option>
-                    <option value="low" @selected(($severity ?? null) === 'low')>{{ __('archived_logs.filters.severity_low') }}</option>
-                    <option value="other" @selected(($severity ?? null) === 'other')>{{ __('archived_logs.filters.severity_other') }}</option>
+                    <option value="">{{ __('severity.all') }}</option>
+                    <option value="critical" @selected(($severity ?? null) === 'critical')>{{ __('severity.critical') }}</option>
+                    <option value="high" @selected(($severity ?? null) === 'high')>{{ __('severity.high') }}</option>
+                    <option value="medium" @selected(($severity ?? null) === 'medium')>{{ __('severity.medium') }}</option>
+                    <option value="low" @selected(($severity ?? null) === 'low')>{{ __('severity.low') }}</option>
+                    <option value="other" @selected(($severity ?? null) === 'other')>{{ __('severity.other') }}</option>
                 </select>
             </div>
 

--- a/resources/views/components/dashboard-card.blade.php
+++ b/resources/views/components/dashboard-card.blade.php
@@ -1,0 +1,19 @@
+<a
+    href="{{ $href }}"
+    class="block rounded-2xl border {{ $borderClass }} {{ $backgroundClass }} p-6 min-h-44 shadow-sm hover:shadow-md transition ring-1 ring-black/5 dark:ring-white/10"
+>
+    <div class="text-2xl font-extrabold uppercase tracking-wide {{ $accentTextClass }}">
+        {{ $title }}
+    </div>
+
+    <div class="mt-6 flex items-end justify-between gap-6">
+        <div>
+            <div class="text-xs uppercase tracking-wide {{ $accentTextClass }}">{{ $unresolvedLabel }}</div>
+            <div class="text-2xl font-bold leading-none {{ $accentTextClass }}">{{ $unresolvedCount }}</div>
+        </div>
+        <div class="text-right">
+            <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-200/80">{{ $resolvedLabel }}</div>
+            <div class="text-2xl font-bold leading-none text-slate-600 dark:text-slate-100">{{ $resolvedCount }}</div>
+        </div>
+    </div>
+</a>

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -9,17 +9,17 @@
     @vite('resources/css/app.css')
     @livewireStyles
 </head>
-<body class="min-h-screen bg-slate-100 text-slate-900">
+<body class="min-h-screen bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
     <x-nav />
 
     <div class="max-w-6xl mx-auto px-4 py-6">
         @if (session('status'))
-            <div class="mb-4 rounded-lg bg-emerald-100 text-emerald-800 px-4 py-2 shadow-sm">
+            <div class="mb-4 rounded-lg bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200 px-4 py-2 shadow-sm">
                 {{ session('status') }}
             </div>
         @endif
 
-        <main class="bg-white rounded-2xl shadow-md p-4 md:p-6 border border-[#e2d8eb]">
+        <main class="bg-white dark:bg-slate-900 rounded-2xl shadow-md p-4 md:p-6 border border-[#e2d8eb] dark:border-slate-700">
             {{ $slot }}
         </main>
     </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,5 +1,21 @@
 <x-layout>
-    <h1 class="text-3xl md:text-4xl font-bold text-center text-slate-900 dark:text-slate-100">{{ __('dashboard.title') }}</h1>
+    <div class="w-full flex flex-col gap-4 md:flex-row md:items-center mt-6">
+        <h1 class="text-3xl md:text-4xl font-bold text-slate-900 dark:text-slate-100">{{ __('dashboard.title') }}</h1>
+
+        <form method="GET" action="{{ route('dashboard') }}" class="md:ml-auto">
+            <label class="inline-flex items-center gap-2 rounded-full border border-[#5b3853] dark:border-[#9c6b91] bg-white dark:bg-slate-900 px-4 py-2 text-sm font-medium text-[#5b3853] dark:text-[#f0deea] shadow-sm">
+                <input
+                    type="checkbox"
+                    name="include_archived"
+                    value="1"
+                    @checked($includeArchived)
+                    onchange="this.form.submit()"
+                    class="h-4 w-4 rounded border-slate-300 text-[#5b3853] focus:ring-[#5b3853]/30"
+                >
+                <span>{{ __('dashboard.filters.include_archived') }}</span>
+            </label>
+        </form>
+    </div>
 
     <div class="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3" style="column-gap: 2rem; row-gap: 2rem;">
         @foreach($cards as $card)

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,23 +1,17 @@
 <x-layout>
-    <h1 class="text-xl font-semibold text-center">{{ __('dashboard.title') }}</h1>
-    <p class="text-base text-gray-500 text-center mb-6">{{ __('dashboard.welcome') }}</p>
+    <h1 class="text-3xl md:text-4xl font-bold text-center text-slate-900 dark:text-slate-100">{{ __('dashboard.title') }}</h1>
 
-    <div class="mt-6 overflow-x-auto">
-        <table class="min-w-full text-base">
-            <thead class="bg-slate-50 text-base uppercase tracking-wide text-slate-500">
-                <tr>
-                    <th class="px-3 py-2 text-left">{{ __('logs.table.severity') }}</th>
-                    <th class="px-3 py-2 text-left">{{ __('dashboard.count') }}</th>
-                </tr>
-            </thead>
-            <tbody class="divide-y divide-slate-100 bg-white">
-                @foreach($severityCounts as $severity => $count)
-                    <tr>
-                        <td class="px-3 py-2 text-slate-700 whitespace-nowrap">{{ $severity }}</td>
-                        <td class="px-3 py-2 text-slate-700 whitespace-nowrap">{{ $count }}</td>
-                    </tr>
-                @endforeach
-            </tbody>
-        </table>
+    <div class="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3" style="column-gap: 2rem; row-gap: 2rem;">
+        @foreach($cards as $card)
+            <x-dashboard-card
+                :title="$card['title']"
+                :href="$card['href']"
+                :severity-key="$card['key']"
+                :unresolved-count="$card['unresolvedCount']"
+                :resolved-count="$card['resolvedCount']"
+                :unresolved-label="$unresolvedLabel"
+                :resolved-label="$resolvedLabel"
+            />
+        @endforeach
     </div>
 </x-layout>

--- a/resources/views/error-codes/index.blade.php
+++ b/resources/views/error-codes/index.blade.php
@@ -11,12 +11,12 @@
                     name="severity"
                     class="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-base shadow-sm focus:border-[#5b3853] focus:outline-none focus:ring-2 focus:ring-[#5b3853]/20"
                 >
-                    <option value="">{{ __('error_codes.filters.severity_all') }}</option>
-                    <option value="critical" @selected(($severity ?? null) === 'critical')>{{ __('error_codes.filters.severity_critical') }}</option>
-                    <option value="high" @selected(($severity ?? null) === 'high')>{{ __('error_codes.filters.severity_high') }}</option>
-                    <option value="medium" @selected(($severity ?? null) === 'medium')>{{ __('error_codes.filters.severity_medium') }}</option>
-                    <option value="low" @selected(($severity ?? null) === 'low')>{{ __('error_codes.filters.severity_low') }}</option>
-                    <option value="other" @selected(($severity ?? null) === 'other')>{{ __('error_codes.filters.severity_other') }}</option>
+                    <option value="">{{ __('severity.all') }}</option>
+                    <option value="critical" @selected(($severity ?? null) === 'critical')>{{ __('severity.critical') }}</option>
+                    <option value="high" @selected(($severity ?? null) === 'high')>{{ __('severity.high') }}</option>
+                    <option value="medium" @selected(($severity ?? null) === 'medium')>{{ __('severity.medium') }}</option>
+                    <option value="low" @selected(($severity ?? null) === 'low')>{{ __('severity.low') }}</option>
+                    <option value="other" @selected(($severity ?? null) === 'other')>{{ __('severity.other') }}</option>
                 </select>
             </div>
 

--- a/resources/views/livewire/logs-table.blade.php
+++ b/resources/views/livewire/logs-table.blade.php
@@ -21,12 +21,12 @@
                     wire:model.defer="severityInput"
                     class="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-base shadow-sm focus:border-[#5b3853] focus:outline-none focus:ring-2 focus:ring-[#5b3853]/20"
                 >
-                    <option value="">{{ __('logs.filters.severity_all') }}</option>
-                    <option value="critical">{{ __('logs.filters.severity_critical') }}</option>
-                    <option value="high">{{ __('logs.filters.severity_high') }}</option>
-                    <option value="medium">{{ __('logs.filters.severity_medium') }}</option>
-                    <option value="low">{{ __('logs.filters.severity_low') }}</option>
-                    <option value="other">{{ __('logs.filters.severity_other') }}</option>
+                    <option value="">{{ __('severity.all') }}</option>
+                    <option value="critical">{{ __('severity.critical') }}</option>
+                    <option value="high">{{ __('severity.high') }}</option>
+                    <option value="medium">{{ __('severity.medium') }}</option>
+                    <option value="low">{{ __('severity.low') }}</option>
+                    <option value="other">{{ __('severity.other') }}</option>
                 </select>
             </div>
 


### PR DESCRIPTION
- Se añade cards en dashboard para los grados de Severidad, incluyendo "Todos"
- Se implementa la navegación desde cada card al listado de logs con filtro de severidad aplicado.
- Cada card muestra conteos de resueltos y no resueltos, manteniendo visibles severidades con 0 registros (por ejemplo Medium).
- Se añade un control de alcance en dashboard (Incluir archivados) para alternar entre logs activos (por defecto) y todos los logs.
- Se crea un enum de severidad para centralizar y reutilizar los valores de severidad en validaciones, filtros y lógica de dashboard.
- Se centralizan también las traducciones en claves compartidas para evitar duplicidades entre vistas/módulos.