### PR TITLE
Feature/f 01.2 dashboard card todos

### DIFF
--- a/app/Livewire/LogsTable.php
+++ b/app/Livewire/LogsTable.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use App\Enums\Severity;
 use App\Services\Contracts\LogServiceInterface;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -14,39 +15,45 @@ class LogsTable extends Component
 
     public string $searchInput = '';
     public ?string $severityInput = null;
-    public ?string $archivedInput = null;
+    public ?string $archivedInput = 'not_archived';
     public ?string $resolvedInput = null;
 
     // filtros aplicados (ya validados)
-    public ?string $search = null;
+    #[Url(as: 'search', except: '')]
+    public string $search = '';
+
+    #[Url(as: 'severity', except: null)]
     public ?string $severity = null;
-    public ?string $archived = null;
+
+    #[Url(as: 'archived', except: 'not_archived')]
+    public string $archived = 'not_archived';
+
+    #[Url(as: 'resolved', except: null)]
     public ?string $resolved = null;
 
     public function mount(): void
     {
-        $querySeverity = request()->query('severity');
-        $queryArchived = request()->query('archived');
-
-        if (is_string($querySeverity) && $querySeverity !== '' && in_array($querySeverity, Severity::values(), true)) {
-            $this->severityInput = $querySeverity;
-            $this->severity = $querySeverity;
+        // Backward compatibility for old URLs generated with archived=true
+        if ($this->archived === 'true') {
+            $this->archived = 'all';
         }
 
-        if ($queryArchived === 'true') {
-            $this->archivedInput = null;
-            $this->archived = null;
-            return;
+        if ($this->severity !== null && !in_array($this->severity, Severity::values(), true)) {
+            $this->severity = null;
         }
 
-        if (is_string($queryArchived) && in_array($queryArchived, ['archived', 'not_archived'], true)) {
-            $this->archivedInput = $queryArchived;
-            $this->archived = $queryArchived;
-            return;
+        if (!in_array($this->archived, ['archived', 'not_archived', 'all'], true)) {
+            $this->archived = 'not_archived';
         }
 
-        $this->archivedInput = 'not_archived';
-        $this->archived = 'not_archived';
+        if ($this->resolved !== null && !in_array($this->resolved, ['resolved', 'unresolved'], true)) {
+            $this->resolved = null;
+        }
+
+        $this->searchInput = $this->search;
+        $this->severityInput = $this->severity;
+        $this->archivedInput = $this->archived === 'all' ? null : $this->archived;
+        $this->resolvedInput = $this->resolved;
     }
 
     public function resetFilters(): void
@@ -56,7 +63,7 @@ class LogsTable extends Component
         $this->archivedInput = 'not_archived';
         $this->resolvedInput = null;
 
-        $this->search = null;
+        $this->search = '';
         $this->severity = null;
         $this->archived = 'not_archived';
         $this->resolved = null;
@@ -87,10 +94,10 @@ class LogsTable extends Component
 
         $this->search = $validated['searchInput'] !== null && $validated['searchInput'] !== ''
             ? trim($validated['searchInput'])
-            : null;
+            : '';
 
         $this->severity = $validated['severityInput'] ?: null;
-        $this->archived = $validated['archivedInput'] ?: null;
+        $this->archived = $validated['archivedInput'] ?: 'all';
         $this->resolved = $validated['resolvedInput'] ?: null;
 
         $this->resetPage();
@@ -98,10 +105,12 @@ class LogsTable extends Component
 
     public function render(): View
     {
+        $archivedFilter = $this->archived === 'all' ? null : $this->archived;
+
         $logs = app(LogServiceInterface::class)->searchAndFilter(
-            $this->search,
+            $this->search !== '' ? $this->search : null,
             $this->severity,
-            $this->archived,
+            $archivedFilter,
             $this->resolved,
             15
         );

--- a/app/Livewire/LogsTable.php
+++ b/app/Livewire/LogsTable.php
@@ -26,23 +26,39 @@ class LogsTable extends Component
     public function mount(): void
     {
         $querySeverity = request()->query('severity');
+        $queryArchived = request()->query('archived');
 
         if (is_string($querySeverity) && $querySeverity !== '' && in_array($querySeverity, Severity::values(), true)) {
             $this->severityInput = $querySeverity;
             $this->severity = $querySeverity;
         }
+
+        if ($queryArchived === 'true') {
+            $this->archivedInput = null;
+            $this->archived = null;
+            return;
+        }
+
+        if (is_string($queryArchived) && in_array($queryArchived, ['archived', 'not_archived'], true)) {
+            $this->archivedInput = $queryArchived;
+            $this->archived = $queryArchived;
+            return;
+        }
+
+        $this->archivedInput = 'not_archived';
+        $this->archived = 'not_archived';
     }
 
     public function resetFilters(): void
     {
         $this->searchInput = '';
         $this->severityInput = null;
-        $this->archivedInput = null;
+        $this->archivedInput = 'not_archived';
         $this->resolvedInput = null;
 
         $this->search = null;
         $this->severity = null;
-        $this->archived = null;
+        $this->archived = 'not_archived';
         $this->resolved = null;
 
         $this->resetPage();

--- a/app/Livewire/LogsTable.php
+++ b/app/Livewire/LogsTable.php
@@ -27,16 +27,10 @@ class LogsTable extends Component
     {
         $querySeverity = request()->query('severity');
 
-        if (!is_string($querySeverity) || $querySeverity === '') {
-            return;
+        if (is_string($querySeverity) && $querySeverity !== '' && in_array($querySeverity, Severity::values(), true)) {
+            $this->severityInput = $querySeverity;
+            $this->severity = $querySeverity;
         }
-
-        if (!in_array($querySeverity, Severity::values(), true)) {
-            return;
-        }
-
-        $this->severityInput = $querySeverity;
-        $this->severity = $querySeverity;
     }
 
     public function resetFilters(): void

--- a/app/Repositories/Contracts/LogRepositoryInterface.php
+++ b/app/Repositories/Contracts/LogRepositoryInterface.php
@@ -36,6 +36,11 @@ interface LogRepositoryInterface
     public function severityResolvedCounts(bool $includeArchived = false): array;
 
     /**
+     * Total logs count (COUNT(*)) for selected scope.
+     */
+    public function logsCount(bool $includeArchived = false): int;
+
+    /**
      * Devuelve el id de ArchivedLog asociado al log (matched_archived_log_id) o null si no está archivado.
      */
     public function archivedLogIdFor(int $logId): ?int;

--- a/app/Repositories/Eloquent/LogRepository.php
+++ b/app/Repositories/Eloquent/LogRepository.php
@@ -101,6 +101,13 @@ class LogRepository implements LogRepositoryInterface
         return $result;
     }
 
+    public function logsCount(bool $includeArchived = false): int
+    {
+        return Log::query()
+            ->when(!$includeArchived, fn ($q) => $q->whereNull('matched_archived_log_id'))
+            ->count();
+    }
+
     public function archivedLogIdFor(int $logId): ?int
     {
         $matchedId = Log::query()

--- a/app/Services/LogService.php
+++ b/app/Services/LogService.php
@@ -66,7 +66,7 @@ class LogService implements LogServiceInterface
                         'resolvedCount' => $resolvedCount,
                         'unresolvedCount' => $unresolvedCount,
                         'routeParams' => $includeArchived
-                            ? ['severity' => $key, 'archived' => 'true']
+                            ? ['severity' => $key, 'archived' => 'all']
                             : ['severity' => $key],
                     ];
                 })
@@ -80,7 +80,7 @@ class LogService implements LogServiceInterface
                 'count' => $totalLogsCount,
                 'resolvedCount' => $allResolved,
                 'unresolvedCount' => $allUnresolved,
-                'routeParams' => $includeArchived ? ['archived' => 'true'] : [],
+                'routeParams' => $includeArchived ? ['archived' => 'all'] : [],
             ]);
 
             return $cards->all();

--- a/app/Services/LogService.php
+++ b/app/Services/LogService.php
@@ -7,6 +7,7 @@ use App\Models\Log;
 use App\Repositories\Contracts\LogRepositoryInterface;
 use App\Services\Contracts\LogServiceInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Cache;
 
 class LogService implements LogServiceInterface
 {
@@ -47,38 +48,43 @@ class LogService implements LogServiceInterface
 
     public function dashboardSeverityCards(bool $includeArchived = false): array
     {
-        $severityKeys = Severity::values();
-        $bySeverity = $this->logRepository->severityResolvedCounts($includeArchived);
+        $cacheKey = sprintf('dashboard:severity-cards:%s', $includeArchived ? 'all' : 'active');
 
-        $cards = collect($severityKeys)
-            ->map(function (string $key) use ($bySeverity, $includeArchived): array {
-                $resolvedCount = (int) ($bySeverity[$key]['resolved'] ?? 0);
-                $unresolvedCount = (int) ($bySeverity[$key]['unresolved'] ?? 0);
+        return Cache::remember($cacheKey, now()->addSeconds(10), function () use ($includeArchived): array {
+            $severityKeys = Severity::values();
+            $bySeverity = $this->logRepository->severityResolvedCounts($includeArchived);
+            $totalLogsCount = $this->logRepository->logsCount($includeArchived);
 
-                return [
-                    'key' => $key,
-                    'count' => $resolvedCount + $unresolvedCount,
-                    'resolvedCount' => $resolvedCount,
-                    'unresolvedCount' => $unresolvedCount,
-                    'routeParams' => $includeArchived
-                        ? ['severity' => $key]
-                        : ['severity' => $key, 'archived' => 'not_archived'],
-                ];
-            })
-            ->values();
+            $cards = collect($severityKeys)
+                ->map(function (string $key) use ($bySeverity, $includeArchived): array {
+                    $resolvedCount = (int) ($bySeverity[$key]['resolved'] ?? 0);
+                    $unresolvedCount = (int) ($bySeverity[$key]['unresolved'] ?? 0);
 
-        $allResolved = (int) $cards->sum('resolvedCount');
-        $allUnresolved = (int) $cards->sum('unresolvedCount');
+                    return [
+                        'key' => $key,
+                        'count' => $resolvedCount + $unresolvedCount,
+                        'resolvedCount' => $resolvedCount,
+                        'unresolvedCount' => $unresolvedCount,
+                        'routeParams' => $includeArchived
+                            ? ['severity' => $key]
+                            : ['severity' => $key, 'archived' => 'not_archived'],
+                    ];
+                })
+                ->values();
 
-        $cards->prepend([
-            'key' => 'all',
-            'count' => $allResolved + $allUnresolved,
-            'resolvedCount' => $allResolved,
-            'unresolvedCount' => $allUnresolved,
-            'routeParams' => [],
-        ]);
+            $allResolved = (int) $cards->sum('resolvedCount');
+            $allUnresolved = (int) $cards->sum('unresolvedCount');
 
-        return $cards->all();
+            $cards->prepend([
+                'key' => 'all',
+                'count' => $totalLogsCount,
+                'resolvedCount' => $allResolved,
+                'unresolvedCount' => $allUnresolved,
+                'routeParams' => [],
+            ]);
+
+            return $cards->all();
+        });
     }
 
     public function archivedLogIdFor(int $logId): ?int

--- a/app/Services/LogService.php
+++ b/app/Services/LogService.php
@@ -66,8 +66,8 @@ class LogService implements LogServiceInterface
                         'resolvedCount' => $resolvedCount,
                         'unresolvedCount' => $unresolvedCount,
                         'routeParams' => $includeArchived
-                            ? ['severity' => $key]
-                            : ['severity' => $key, 'archived' => 'not_archived'],
+                            ? ['severity' => $key, 'archived' => 'true']
+                            : ['severity' => $key],
                     ];
                 })
                 ->values();
@@ -80,7 +80,7 @@ class LogService implements LogServiceInterface
                 'count' => $totalLogsCount,
                 'resolvedCount' => $allResolved,
                 'unresolvedCount' => $allUnresolved,
-                'routeParams' => [],
+                'routeParams' => $includeArchived ? ['archived' => 'true'] : [],
             ]);
 
             return $cards->all();

--- a/database/data/mock-logs.php
+++ b/database/data/mock-logs.php
@@ -27,4 +27,24 @@ foreach ($severities as $severity) {
     }
 }
 
+for($i = 1; $i <= 5; $i++) {
+    $rows[] = [
+        'id' => $id++,
+        'application_id' => 1,
+        'error_code_id' => 1,
+        'severity' => 'medium',
+        'message' => sprintf('Seed: medium log #%02d', $i),
+        'file' => sprintf('seed/medium.log', $i),
+        'line' => 100 + $i,
+        'metadata' => [
+            'seed' => true,
+            'source' => 'mock-logs.php',
+            'batch' => 'dashboard-cards',
+        ],
+        'matched_archived_log_id' => null,
+        'resolved' => false,
+        'created_at' => $baseDate->modify('-' . (($id - 1) * 3) . ' minutes')->format('Y-m-d H:i:s'),
+    ];
+}
+
 return $rows;


### PR DESCRIPTION
- Se completa la card especial “Todos” en dashboard para mostrar el total acumulado de logs según el alcance activo/incluir archivados.
- Se implementa conteo explícito con COUNT(*) en backend y se integra en la misma caché corta (10s) de agregados del dashboard.
- Se asegura consistencia entre card “Todos” y cards por severidad, manteniendo la navegación sin filtro de tipo en “Todos”.
- Se actualiza el mock-logs para validar correctamente escenarios de total y consistencia.