### PR TITLE
fix: correct log seeder to insert processed rows instead of mock logs

### DIFF
--- a/database/seeders/LogSeeder.php
+++ b/database/seeders/LogSeeder.php
@@ -18,7 +18,7 @@ class LogSeeder extends Seeder
             return $row;
         }, $mockLogs);
         
-        DB::table('logs')->insert($mockLogs);
+        DB::table('logs')->insert($rows);
 
         DB::statement(
             "SELECT setval(pg_get_serial_sequence('logs', 'id'), (SELECT COALESCE(MAX(id), 1) FROM logs))"


### PR DESCRIPTION
Corrección mínima en LogSeeder.php.