### PR TITLE
Feature/f 06.2 detalle crear editar codigo error

### DIFF
--- a/resources/views/livewire/error-code-form.blade.php
+++ b/resources/views/livewire/error-code-form.blade.php
@@ -161,6 +161,14 @@
                     >
                         {{ __('error_codes.buttons.edit') }}
                     </button>
+
+                    <button
+                        type="button"
+                        x-on:click="confirmDeleteOpen = true"
+                        class="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-4 py-2 text-base font-semibold text-red-700 hover:bg-red-100"
+                    >
+                        {{ __('error_codes.buttons.delete') }}
+                    </button>
                 @endif
 
                 @if ($isEditable)
@@ -179,14 +187,6 @@
                         {{ __('error_codes.buttons.save') }}
                     </button>
                 @endif
-
-                <button
-                    type="button"
-                    x-on:click="confirmDeleteOpen = true"
-                    class="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-4 py-2 text-base font-semibold text-red-700 hover:bg-red-100"
-                >
-                    {{ __('error_codes.buttons.delete') }}
-                </button>
             @endif
         </div>
     </form>

--- a/resources/views/livewire/error-codes-table.blade.php
+++ b/resources/views/livewire/error-codes-table.blade.php
@@ -52,7 +52,6 @@
                     <th class="px-3 py-2 text-left">{{ __('error_codes.table.name') }}</th>
                     <th class="px-3 py-2 text-left">{{ __('error_codes.table.file') }}</th>
                     <th class="px-3 py-2 text-left">{{ __('error_codes.table.line') }}</th>
-                    <th class="px-3 py-2 text-left">{{ __('error_codes.table.actions') }}</th>
                 </tr>
             </thead>
 
@@ -69,35 +68,10 @@
                     <td class="px-3 py-2 text-slate-700 dark:text-slate-200">{{ $item->name ?? '-' }}</td>
                     <td class="px-3 py-2 text-slate-700 dark:text-slate-200">{{ $item->file ?? '-' }}</td>
                     <td class="px-3 py-2 text-slate-700 dark:text-slate-200">{{ $item->line ?? '-' }}</td>
-                    <td class="px-3 py-2 text-slate-700 dark:text-slate-200 whitespace-nowrap">
-                        <div class="flex gap-2">
-                            <a
-                                href="{{ route('error-codes.show', $item->id) }}"
-                                onclick="event.stopPropagation()"
-                                class="inline-flex items-center rounded-full border border-slate-300 bg-white px-3 py-1 text-sm font-semibold text-slate-800 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-                            >
-                                {{ __('error_codes.buttons.edit') }}
-                            </a>
-
-                            <button
-                                type="button"
-                                onclick="event.stopPropagation()"
-                                x-on:click="confirmDeleteOpen = true"
-                                class="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-3 py-1 text-sm font-semibold text-red-700 hover:bg-red-100"
-                            >
-                                {{ __('error_codes.buttons.delete') }}
-                            </button>
-
-                            <x-confirm-delete-modal
-                                :action="route('error-codes.destroy', $item->id)"
-                                openVar="confirmDeleteOpen"
-                            />
-                        </div>
-                    </td>
                 </tr>
             @empty
                 <tr>
-                    <td colspan="6" class="px-3 py-4 text-center text-base text-slate-500 dark:text-slate-400">
+                    <td colspan="5" class="px-3 py-4 text-center text-base text-slate-500 dark:text-slate-400">
                         {{ __('error_codes.empty') }}
                     </td>
                 </tr>


### PR DESCRIPTION
This pull request makes changes to the error codes management UI, primarily by moving the "delete" button from the error codes table view to the error code form view. This streamlines the user interface and ensures that deletion actions are only available when editing a specific error code.

**UI changes to error code management:**

* Removed the "Actions" column (which included Edit and Delete actions) from the `error-codes-table` view, simplifying the table display. [[1]](diffhunk://#diff-9c98c1e6790f2a60ebabb37bf4ec2f322407bd93fc8e286487e1705278223461L55) [[2]](diffhunk://#diff-9c98c1e6790f2a60ebabb37bf4ec2f322407bd93fc8e286487e1705278223461L72-R74)
* Moved the "Delete" button into the `error-code-form` view, so deletion is now only possible when editing an individual error code. [[1]](diffhunk://#diff-8fcc6f4a968caccbd86ee37efef5c292105d1ed3b23287f24b9c94c83bf7a52eR164-R171) [[2]](diffhunk://#diff-8fcc6f4a968caccbd86ee37efef5c292105d1ed3b23287f24b9c94c83bf7a52eL182-L189)
* Adjusted the empty state message in the table to account for the reduced number of columns.