### PR TITLE
Feature/refactor log resueltos

### DIFF
--- a/app/Http/Controllers/LogController.php
+++ b/app/Http/Controllers/LogController.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Throwable;
 
@@ -60,7 +59,7 @@ class LogController extends Controller
 
     public function resolve(int $id): RedirectResponse
     {
-        DB::table('logs')->where('id', $id)->update(['resolved' => true]);
+        $this->logService->markResolved($id);
 
         return redirect()->route('logs.show', $id);
     }

--- a/app/Repositories/Contracts/LogRepositoryInterface.php
+++ b/app/Repositories/Contracts/LogRepositoryInterface.php
@@ -49,4 +49,9 @@ interface LogRepositoryInterface
      * Devuelve el id de ArchivedLog equivalente al log o null si no está archivado.
      */
     public function archivedLogIdFor(int $logId): ?int;
+
+    /**
+     * Marca el log como resuelto (resolved = true).
+     */
+    public function markResolved(int $logId): void;
 }

--- a/app/Repositories/Eloquent/LogRepository.php
+++ b/app/Repositories/Eloquent/LogRepository.php
@@ -218,6 +218,16 @@ class LogRepository implements LogRepositoryInterface
     }
 
     /**
+     * Marca el log como resuelto.
+     *
+     * Se usa el query builder: el modelo {@see Log} cancela actualizaciones vía Eloquent en {@see Log::booted()}.
+     */
+    public function markResolved(int $logId): void
+    {
+        DB::table('logs')->where('id', $logId)->update(['resolved' => true]);
+    }
+
+    /**
      * Aplica a una subquery la condición de equivalencia lógica
      * archived_logs <-> logs (sin FK; misma aplicación, código de error, severidad y mensaje).
      *
@@ -254,4 +264,5 @@ class LogRepository implements LogRepositoryInterface
             $value,
         );
     }
+
 }

--- a/app/Services/Contracts/LogServiceInterface.php
+++ b/app/Services/Contracts/LogServiceInterface.php
@@ -50,4 +50,9 @@ interface LogServiceInterface
      * Devuelve el id de ArchivedLog equivalente al log o null si no está archivado.
      */
     public function archivedLogIdFor(int $logId): ?int;
+
+    /**
+     * Marca el log como resuelto.
+     */
+    public function markResolved(int $logId): void;
 }

--- a/app/Services/LogService.php
+++ b/app/Services/LogService.php
@@ -136,6 +136,14 @@ class LogService implements LogServiceInterface
     }
 
     /**
+     * Marca el log como resuelto.
+     */
+    public function markResolved(int $logId): void
+    {
+        $this->logRepository->markResolved($logId);
+    }
+
+    /**
      * Construye una card del dashboard con estado resolved/unresolved.
      * 
      * @return array{key:string,totalCount:int,resolvedCount:int,unresolvedCount:int}

--- a/lang/en/logs.php
+++ b/lang/en/logs.php
@@ -73,6 +73,6 @@ return [
         'cancel' => 'Cancel',
         'archive' => 'Save to history',
         'view_archived' => 'View archived',
-        'solved' => 'Resolve',
+        'solved' => 'Mark as resolved',
     ],
 ];

--- a/lang/es/logs.php
+++ b/lang/es/logs.php
@@ -73,6 +73,6 @@ return [
         'cancel' => 'Cancelar',
         'archive' => 'Guardar en Histórico',
         'view_archived' => 'Ver archivado',
-        'solved' => 'Resolver',
+        'solved' => 'Marcar como resuelto',
     ],
 ];

--- a/lang/va/logs.php
+++ b/lang/va/logs.php
@@ -73,6 +73,6 @@ return [
         'cancel' => 'Cancel·lar',
         'archive' => "Desar a l'històric",
         'view_archived' => 'Veure arxivat',
-        'solved' => 'Resoldre',
+        'solved' => 'Marcar com a resolt',
     ],
 ];

--- a/tests/Feature/LogMarkResolvedTest.php
+++ b/tests/Feature/LogMarkResolvedTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Application;
+use App\Models\ErrorCode;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class LogMarkResolvedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_resolve_route_marks_log_resolved_and_redirects_to_detail(): void
+    {
+        [$user, $application, $errorCode] = $this->seedBaseData();
+
+        $logId = DB::table('logs')->insertGetId([
+            'error_code_id' => $errorCode->id,
+            'application_id' => $application->id,
+            'severity' => 'critical',
+            'message' => 'Log to resolve',
+            'file' => 'app/Test.php',
+            'line' => 1,
+            'metadata' => json_encode([]),
+            'resolved' => false,
+            'created_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->patch(route('logs.resolve', $logId))
+            ->assertRedirect(route('logs.show', $logId));
+
+        $this->assertDatabaseHas('logs', [
+            'id' => $logId,
+            'resolved' => true,
+        ]);
+    }
+
+    /**
+     * @return array{0: User, 1: Application, 2: ErrorCode}
+     */
+    private function seedBaseData(): array
+    {
+        $user = User::factory()->create();
+
+        $application = Application::query()->create([
+            'name' => 'Resolve Test App',
+            'description' => 'Test app',
+            'created_at' => now(),
+        ]);
+
+        $errorCode = ErrorCode::query()->create([
+            'code' => 'RES-001',
+            'application_id' => $application->id,
+            'name' => 'Resolve test error',
+            'description' => null,
+            'severity' => 'high',
+        ]);
+
+        return [$user, $application, $errorCode];
+    }
+}

--- a/tests/Unit/LogServiceMarkResolvedTest.php
+++ b/tests/Unit/LogServiceMarkResolvedTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Repositories\Contracts\LogRepositoryInterface;
+use App\Services\LogService;
+use PHPUnit\Framework\TestCase;
+
+class LogServiceMarkResolvedTest extends TestCase
+{
+    public function test_mark_resolved_delegates_to_repository(): void
+    {
+        $repository = $this->createMock(LogRepositoryInterface::class);
+        $repository->expects($this->once())
+            ->method('markResolved')
+            ->with(42);
+
+        $service = new LogService($repository);
+        $service->markResolved(42);
+    }
+}


### PR DESCRIPTION
- Se mejora la funcionalidad de resolver un log usando el Service y el Repository, siguiendo la arquitectura del resto del proyecto.
- Se modifica el texto del botón "Resolver" de la vista detalle de logs, poniendo en su lugar "Marcar como resuelto".
- Se añaden tests: unitario sobre la delegación en LogService y test de feature para la ruta de marcar como resuelto.