### PR TITLE
Feature/refactor 07

### DIFF
--- a/app/Http/Middleware/AuthGateway.php
+++ b/app/Http/Middleware/AuthGateway.php
@@ -7,10 +7,9 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
-use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Throwable;
-
-use App\Http\Middleware\AuthMock;
 
 /**
  * Intenta enlazar la sesión del panel con un servicio de autenticación externo (cookie `session_token`
@@ -21,12 +20,15 @@ use App\Http\Middleware\AuthMock;
  * sin usuario por este paso. En producción/staging, una URL mal configurada debe fallar al arrancar
  * (AuthExternalUrlGuard en AppServiceProvider). Tras intentar validar, si el token no es válido o no
  * hay usuario local asociado, la petición también continúa; el acceso queda otra vez en manos de `auth`.
+ *
+ * Logging: los pass-through se registran para auditoría. El caso `no_session_token` usa nivel `debug`
+ * para no saturar logs en el flujo normal de invitados antes del redirect de `auth`.
  */
 class AuthGateway
 {
-    public function __construct(private AuthMock $authMock){}
+    public function __construct(private AuthMock $authMock) {}
 
-    public function handle(Request $request, Closure $next): Response
+    public function handle(Request $request, Closure $next): SymfonyResponse
     {
         if (Auth::check()) {
             return $next($request);
@@ -34,7 +36,7 @@ class AuthGateway
 
         // En local no se usa el servicio externo: sesión mock para desarrollo (ver AuthMock).
         if (app()->environment('local')) {
-            return ($this->authMock)->handle($request, $next);
+            return $this->authMock->handle($request, $next);
         }
 
         $token = $request->cookie('session_token') ?: $request->bearerToken();
@@ -43,7 +45,9 @@ class AuthGateway
         Sin token de sesión: se sigue la petición sin autenticar por este middleware.
         El acceso a rutas protegidas sigue dependiendo del middleware `auth` de Laravel (y de las policies).
         */
-        if (!$token) {
+        if (! $token) {
+            $this->logPassThrough($request, 'no_session_token', 'debug');
+
             return $next($request);
         }
 
@@ -54,20 +58,30 @@ class AuthGateway
         "paso" que arriba. En producción/staging, AppServiceProvider debería impedir arrancar con esta mala configuración.
         */
         if ($externalBaseUrl === '') {
+            $this->logPassThrough($request, 'missing_external_auth_base_url');
+
             return $next($request);
         }
+
+        $failureReason = 'unknown';
+        $failureContext = [];
 
         try {
             $response = Http::acceptJson()
                 ->withToken($token)
                 ->timeout(3)
-                ->get($externalBaseUrl . '/validate');
+                ->get($externalBaseUrl.'/validate');
 
-            if ($response->successful()) {
-                $payload = $response->json();
+            if (! $response->successful()) {
+                $failureReason = 'external_validate_http_not_successful';
+                $failureContext['http_status'] = $response->status();
+            } else {
+                $payload = $response->json() ?? [];
                 $externalId = $payload['id'] ?? null;
 
-                if ($externalId !== null) {
+                if ($externalId === null) {
+                    $failureReason = 'missing_external_id_in_payload';
+                } else {
                     $user = User::query()
                         ->where('external_id', (string) $externalId)
                         ->orWhere('id', (int) $externalId)
@@ -75,17 +89,47 @@ class AuthGateway
 
                     if ($user) {
                         Auth::login($user);
+                    } else {
+                        $failureReason = 'no_local_user_for_external_id';
                     }
                 }
             }
         } catch (Throwable $e) {
             report($e);
+            $failureReason = 'exception_during_validate';
+            $failureContext['exception'] = $e::class;
         }
 
         /*
         Llegamos aquí si no hubo login (respuesta error, payload inválido, usuario inexistente, etc.).
         La petición sigue; la protección real sigue siendo `auth` en la ruta.
          */
+        if (! Auth::check()) {
+            $this->logPassThrough($request, 'after_external_validate_attempt', 'warning', array_merge([
+                'failure_reason' => $failureReason,
+            ], $failureContext));
+        }
+
         return $next($request);
+    }
+
+    /**
+     * @param  'debug'|'warning'  $level
+     */
+    private function logPassThrough(Request $request, string $reason, string $level = 'warning', array $extra = []): void
+    {
+        $context = array_merge([
+            'reason' => $reason,
+            'path' => $request->path(),
+            'method' => $request->method(),
+        ], $extra);
+
+        $message = 'AuthGateway: pass-through without gateway authentication';
+
+        if ($level === 'debug') {
+            Log::debug($message, $context);
+        } else {
+            Log::warning($message, $context);
+        }
     }
 }

--- a/tests/Feature/AuthGatewayLoggingTest.php
+++ b/tests/Feature/AuthGatewayLoggingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Mockery\LegacyMockInterface;
+use Tests\TestCase;
+
+class AuthGatewayLoggingTest extends TestCase
+{
+    public function test_logs_debug_when_guest_request_has_no_session_token(): void
+    {
+        /** @var LegacyMockInterface $spy */
+        $spy = Log::spy();
+
+        $this->get('/');
+
+        $spy->shouldHaveReceived('debug')->withArgs(function (string $message, array $context) {
+            return str_contains($message, 'AuthGateway')
+                && ($context['reason'] ?? null) === 'no_session_token';
+        });
+    }
+
+    public function test_logs_warning_when_session_token_present_but_validate_returns_non_success(): void
+    {
+        /** @var LegacyMockInterface $spy */
+        $spy = Log::spy();
+
+        Http::fake([
+            'http://auth.example.com/*' => Http::response(['error' => 'invalid'], 401),
+        ]);
+
+        $this->withCookie('session_token', 'invalid-token')
+            ->get('/');
+
+        $spy->shouldHaveReceived('warning')->withArgs(function (string $message, array $context) {
+            return str_contains($message, 'AuthGateway')
+                && ($context['reason'] ?? null) === 'after_external_validate_attempt'
+                && ($context['failure_reason'] ?? null) === 'external_validate_http_not_successful'
+                && ($context['http_status'] ?? null) === 401;
+        });
+    }
+}


### PR DESCRIPTION
- Comentarios y docblock aclarando la relación con el middleware auth.
- Registro de pass-through: warning o debug según el caso; no_session_token en debug para no saturar el volumen de logs.
- Tests que verifican las llamadas a log con Log::spy().