### PR TITLE
Feature/afinar trazabilidad logs auditoria

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,7 +27,7 @@ RABBITMQ_PORT=5672
 RABBITMQ_USER=admin
 RABBITMQ_PASSWORD=admin
 RABBITMQ_VHOST=/
-MAYA_MESSAGING_APP=maya_logs
+MAYA_MESSAGING_APP=maya-logs
 
 # Zona IANA para occurred_at y fechas en payloads de auditoría (alinear con la UI en hora local).
 # MAYA_AUDIT_TIMESTAMP_TIMEZONE=Europe/Madrid

--- a/backend/app/Listeners/PublishTelemetryOnAuditPublishFailure.php
+++ b/backend/app/Listeners/PublishTelemetryOnAuditPublishFailure.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Support\ResilientLogPublisher;
+use Illuminate\Log\Events\MessageLogged;
+
+/**
+ * Cuando {@see \Maya\Messaging\Publishers\AuditPublisher} no puede publicar en maya.audit,
+ * deja `Log::warning('audit.publish_failed', …)`. Este listener replica la incidencia en
+ * maya.logs con LAR-LOG-020 para que aparezca en el panel (si el broker de logs responde).
+ */
+final class PublishTelemetryOnAuditPublishFailure
+{
+    private const TELEMETRY_CODE = 'LAR-LOG-020';
+
+    public function __construct(
+        private readonly ResilientLogPublisher $resilientLogPublisher,
+    ) {}
+
+    public function handle(MessageLogged $event): void
+    {
+        if ($event->level !== 'warning' || $event->message !== 'audit.publish_failed') {
+            return;
+        }
+
+        $context = $event->context;
+        $brokerError = $context['error'] ?? null;
+        $message = is_string($brokerError) && $brokerError !== ''
+            ? $brokerError
+            : 'Fallo al publicar evento de auditoría en maya.audit';
+
+        $this->resilientLogPublisher->publishStructured(
+            'high',
+            $message,
+            self::TELEMETRY_CODE,
+            [
+                'exchange' => $context['exchange'] ?? null,
+                'application_slug' => $context['application_slug'] ?? null,
+                'entity_type' => $context['entity_type'] ?? null,
+                'entity_id' => $context['entity_id'] ?? null,
+                'action' => $context['action'] ?? null,
+                'user_id' => $context['user_id'] ?? null,
+            ],
+            (string) config('messaging.app'),
+        );
+    }
+}

--- a/backend/app/Observers/AbstractAuditableModelObserver.php
+++ b/backend/app/Observers/AbstractAuditableModelObserver.php
@@ -87,6 +87,26 @@ abstract class AbstractAuditableModelObserver
         DB::afterCommit($callback);
     }
 
+    protected function messagingAppSlug(): string
+    {
+        return (string) config('messaging.app');
+    }
+
+    /**
+     * Subject JWT del request actual (panel API). Null fuera de HTTP o sin `jwt_user`.
+     */
+    protected function jwtSubjectFromRequest(): ?string
+    {
+        $jwtUser = request()->attributes->get('jwt_user');
+        if (! is_array($jwtUser)) {
+            return null;
+        }
+
+        $id = $jwtUser['id'] ?? null;
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
     /**
      * @param  array<string, mixed>|null  $previousValue
      * @param  array<string, mixed>|null  $newValue
@@ -98,7 +118,7 @@ abstract class AbstractAuditableModelObserver
         ?array $newValue,
     ): void {
         $this->publisher->publish(
-            applicationSlug: 'maya-logs', //(string) config('messaging.app'),
+            applicationSlug: $this->messagingAppSlug(),
             entityType: $this->auditEntityType(),
             entityId: (string) $model->getKey(),
             action: $action,

--- a/backend/app/Observers/AbstractAuditableModelObserver.php
+++ b/backend/app/Observers/AbstractAuditableModelObserver.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Observers;
+
+use App\Observers\Concerns\NormalizesAuditTemporalPayload;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Maya\Messaging\Publishers\AuditPublisher;
+
+/**
+ * Plantilla CRUD → maya.audit para modelos del panel.
+ *
+ * Cada observer concreto define tipo de entidad, claves temporales y actor;
+ * la publicación y el diferimiento al commit son compartidos.
+ */
+abstract class AbstractAuditableModelObserver
+{
+    use NormalizesAuditTemporalPayload;
+
+    public function __construct(
+        protected readonly AuditPublisher $publisher,
+    ) {}
+
+    abstract protected function auditEntityType(): string;
+
+    /**
+     * @return list<string>
+     */
+    abstract protected function auditTemporalKeys(): array;
+
+    abstract protected function resolveAuditUserId(Model $model): string;
+
+    protected function auditAfterCreate(string $action, Model $model): void
+    {
+        $this->afterCommit(fn () => $this->publishAudit(
+            $action,
+            $model,
+            null,
+            $model->getAttributes(),
+        ));
+    }
+
+    protected function auditAfterUpdate(string $action, Model $model): void
+    {
+        [$previous, $new] = $this->auditUpdateDiff($model);
+
+        $this->afterCommit(fn () => $this->publishAudit(
+            $action,
+            $model,
+            $previous,
+            $new,
+        ));
+    }
+
+    protected function auditAfterDelete(string $action, Model $model): void
+    {
+        $this->afterCommit(fn () => $this->publishAudit(
+            $action,
+            $model,
+            $model->getAttributes(),
+            null,
+        ));
+    }
+
+    /**
+     * @return array{0: ?array<string, mixed>, 1: ?array<string, mixed>}
+     */
+    protected function auditUpdateDiff(Model $model): array
+    {
+        $previous = array_intersect_key($model->getOriginal(), $model->getChanges());
+        $new = $model->getChanges();
+
+        return [
+            $previous !== [] ? $previous : null,
+            $new !== [] ? $new : null,
+        ];
+    }
+
+    protected function afterCommit(callable $callback): void
+    {
+        if (DB::transactionLevel() === 0) {
+            $callback();
+
+            return;
+        }
+
+        DB::afterCommit($callback);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $previousValue
+     * @param  array<string, mixed>|null  $newValue
+     */
+    protected function publishAudit(
+        string $action,
+        Model $model,
+        ?array $previousValue,
+        ?array $newValue,
+    ): void {
+        $this->publisher->publish(
+            applicationSlug: 'maya-logs', //(string) config('messaging.app'),
+            entityType: $this->auditEntityType(),
+            entityId: (string) $model->getKey(),
+            action: $action,
+            userId: $this->resolveAuditUserId($model),
+            previousValue: $this->normalizeAuditTemporalPayload($previousValue, $this->auditTemporalKeys()),
+            newValue: $this->normalizeAuditTemporalPayload($newValue, $this->auditTemporalKeys()),
+        );
+    }
+}

--- a/backend/app/Observers/ArchivedLogObserver.php
+++ b/backend/app/Observers/ArchivedLogObserver.php
@@ -3,168 +3,61 @@
 namespace App\Observers;
 
 use App\Models\ArchivedLog;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
-use Maya\Messaging\Publishers\AuditPublisher;
+use Illuminate\Database\Eloquent\Model;
 
 /**
- * Sin transacción activa, la publicación es inmediata; dentro de `DB::transaction`, se difiere al commit.
  * Actor: {@see ArchivedLog::$archived_by_id} (coherente con el panel JWT / policy).
- *
- * Las fechas en previous/new usan la misma regla que {@see AuditPublisher::occurredAtForPayload()}
- * (`config('messaging.audit_timestamp_timezone')`): ISO 8601 con offset local si está definida,
- * si no UTC con sufijo Z.
  */
-final class ArchivedLogObserver
+final class ArchivedLogObserver extends AbstractAuditableModelObserver
 {
-    private const ENTITY_TYPE = 'archived_log';
-
-    /** Campos {@see ArchivedLog} serializados como instantes en el payload de auditoría. */
-    private const AUDIT_TEMPORAL_KEYS = [
-        'archived_at',
-        'updated_at',
-        'deleted_at',
-        'original_created_at',
-    ];
-
-    public function __construct(
-        private readonly AuditPublisher $publisher,
-    ) {}
-
     /**
-     * Registra la auditoría de la creación de un log archivado.
-     *
-     * @param  ArchivedLog  $archivedLog  El log archivado que se está creando.
+     * @return list<string>
      */
+    protected function auditTemporalKeys(): array
+    {
+        return [
+            'archived_at',
+            'updated_at',
+            'deleted_at',
+            'original_created_at',
+        ];
+    }
+
+    protected function auditEntityType(): string
+    {
+        return 'archived_log';
+    }
+
+    protected function resolveAuditUserId(Model $model): string
+    {
+        /** @var ArchivedLog $model */
+        return (string) ($model->archived_by_id ?? 'system');
+    }
+
     public function created(ArchivedLog $archivedLog): void
     {
-        $this->afterCommit(fn () => $this->publish(
-            'Archivar un log',
-            $archivedLog,
-            null,
-            $archivedLog->getAttributes(),
-        ));
+        $this->auditAfterCreate('Archivar un log', $archivedLog);
     }
 
-    /**
-     * Registra la auditoría de la actualización de un log archivado.
-     *
-     * @param  ArchivedLog  $archivedLog  El log archivado que se está actualizando.
-     */
     public function updated(ArchivedLog $archivedLog): void
     {
-        $previous = $archivedLog->getPrevious();
-        $new = $archivedLog->getChanges();
-
-        $this->afterCommit(fn () => $this->publish(
-            'Actualizar un log archivado',
-            $archivedLog,
-            $previous !== [] ? $previous : null,
-            $new !== [] ? $new : null,
-        ));
+        $this->auditAfterUpdate('Actualizar un log archivado', $archivedLog);
     }
 
-    /**
-     * Registra la auditoría de la eliminación de un log archivado.
-     *
-     * @param  ArchivedLog  $archivedLog  El log archivado que se está eliminando.
-     */
     public function deleted(ArchivedLog $archivedLog): void
     {
-        $this->afterCommit(fn () => $this->publish(
-            'Eliminar un log archivado',
-            $archivedLog,
-            $archivedLog->getAttributes(),
-            null,
-        ));
+        $this->auditAfterDelete('Eliminar un log archivado', $archivedLog);
     }
 
-    /**
-     * Con transacción activa, difiere al commit (equivalente a listeners `ShouldHandleEventsAfterCommit`).
-     * Sin transacción, ejecuta de inmediato (tests, comandos sin `DB::transaction`).
-     */
-    private function afterCommit(callable $callback): void
+    protected function auditUpdateDiff(Model $model): array
     {
-        if (DB::transactionLevel() === 0) {
-            $callback();
+        /** @var ArchivedLog $model */
+        $previous = $model->getPrevious();
+        $new = $model->getChanges();
 
-            return;
-        }
-
-        DB::afterCommit($callback);
-    }
-
-    /**
-     * Publica la auditoría de una acción sobre un log archivado.
-     *
-     * @param  string  $action  La acción que se está registrando.
-     * @param  ArchivedLog  $archivedLog  El log archivado que se está registrando.
-     * @param  array<string, mixed>|null  $previousValue  Los valores anteriores de los campos.
-     * @param  array<string, mixed>|null  $newValue  Los nuevos valores de los campos.
-     */
-    private function publish(
-        string $action,
-        ArchivedLog $archivedLog,
-        ?array $previousValue,
-        ?array $newValue,
-    ): void {
-        $userId = (string) ($archivedLog->archived_by_id ?? 'system');
-
-        $this->publisher->publish(
-            applicationSlug: "maya-logs",
-            entityType: self::ENTITY_TYPE,
-            entityId: (string) $archivedLog->getKey(),
-            action: $action,
-            userId: $userId,
-            previousValue: $this->normalizeTemporalPayload($previousValue),
-            newValue: $this->normalizeTemporalPayload($newValue),
-        );
-    }
-
-    /**
-     * @param  array<string, mixed>|null  $payload
-     * @return array<string, mixed>|null
-     */
-    private function normalizeTemporalPayload(?array $payload): ?array
-    {
-        if ($payload === null) {
-            return null;
-        }
-
-        foreach (self::AUDIT_TEMPORAL_KEYS as $key) {
-            if (! array_key_exists($key, $payload)) {
-                continue;
-            }
-            $payload[$key] = $this->toAuditTemporalString($payload[$key]);
-        }
-
-        return $payload;
-    }
-
-    private function toAuditTemporalString(mixed $value): mixed
-    {
-        if ($value === null || $value === '') {
-            return $value;
-        }
-
-        try {
-            $instant = $value instanceof \DateTimeInterface
-                ? Carbon::instance($value)
-                : Carbon::parse((string) $value);
-            $instant = $instant->utc();
-
-            $tz = config('messaging.audit_timestamp_timezone');
-            if (is_string($tz) && $tz !== '') {
-                try {
-                    return $instant->timezone($tz)->toIso8601String();
-                } catch (\Throwable) {
-                    return $instant->toIso8601ZuluString();
-                }
-            }
-
-            return $instant->toIso8601ZuluString();
-        } catch (\Throwable) {
-            return $value;
-        }
+        return [
+            $previous !== [] ? $previous : null,
+            $new !== [] ? $new : null,
+        ];
     }
 }

--- a/backend/app/Observers/CommentObserver.php
+++ b/backend/app/Observers/CommentObserver.php
@@ -1,43 +1,40 @@
 <?php
+
 namespace App\Observers;
 
 use App\Models\Comment;
-use Illuminate\Database\Eloquent\Attributes\ObservedBy;
-use Illuminate\Support\Facades\DB;
-use Maya\Messaging\Publishers\AuditPublisher;
+use Illuminate\Database\Eloquent\Model;
 
-class CommentObserver
+final class CommentObserver extends AbstractAuditableModelObserver
 {
-    public function __construct(private readonly AuditPublisher $publisher) {}
+    protected function auditEntityType(): string
+    {
+        return 'comment';
+    }
+
+    protected function auditTemporalKeys(): array
+    {
+        return self::AUDIT_ELOQUENT_TEMPORAL_KEYS;
+    }
+
+    protected function resolveAuditUserId(Model $model): string
+    {
+        /** @var Comment $model */
+        return (string) ($model->user_id ?? 'system');
+    }
 
     public function created(Comment $comment): void
     {
-        DB::afterCommit(fn () => $this->publish('Creado un comentario', $comment, null, $comment->getAttributes()));
+        $this->auditAfterCreate('Nuevo comentario creado', $comment);
     }
 
     public function updated(Comment $comment): void
     {
-        $previous= array_intersect_key($comment->getOriginal(), $comment->getChanges());
-        DB::afterCommit(fn() => $this->publish('Modificado un comentario', $comment, $previous, $comment->getChanges()));
+        $this->auditAfterUpdate('Comentario modificado', $comment);
     }
 
     public function deleted(Comment $comment): void
     {
-        DB::afterCommit(fn() => $this->publish('Borrado un comentario', $comment, $comment->getAttributes(), null));
-    }
-
-
-    private function publish(string $action, Comment $comment, ?array $previous, ?array $new): void
-    {
-        $userId = (string) ($comment->user_id ?? 'system');
-        $this->publisher->publish(
-            applicationSlug: 'maya-logs',
-            entityType: 'comment',
-            entityId:  (string) $comment->getKey(),
-            action: $action,
-            userId: $userId,
-            previousValue:  $previous,
-            newValue:  $new,
-        );
+        $this->auditAfterDelete('Comentario eliminado', $comment);
     }
 }

--- a/backend/app/Observers/Concerns/NormalizesAuditTemporalPayload.php
+++ b/backend/app/Observers/Concerns/NormalizesAuditTemporalPayload.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Observers\Concerns;
+
+use Illuminate\Support\Carbon;
+use Maya\Messaging\Publishers\AuditPublisher;
+
+/**
+ * Formatea instantes en payloads de auditoría (previous_value / new_value) con la misma
+ * regla que {@see AuditPublisher} para occurred_at cuando
+ * el paquete usa {@see config('messaging.audit_timestamp_timezone')}: ISO 8601 con offset
+ * local; si no, UTC con sufijo Z.
+ */
+trait NormalizesAuditTemporalPayload
+{
+    /** Campos timestamp habituales de Eloquent. */
+    protected const AUDIT_ELOQUENT_TEMPORAL_KEYS = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
+    /**
+     * Normaliza los campos de tiempo en el payload de auditoría.
+     *
+     * @param  array<string, mixed>|null  $payload
+     * @param  list<string>  $temporalKeys
+     * @return array<string, mixed>|null
+     */
+    protected function normalizeAuditTemporalPayload(?array $payload, array $temporalKeys): ?array
+    {
+        if ($payload === null) {
+            return null;
+        }
+
+        foreach ($temporalKeys as $key) {
+            if (! array_key_exists($key, $payload)) {
+                continue;
+            }
+            $payload[$key] = $this->toAuditTemporalString($payload[$key]);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Convierte un valor de tiempo a una cadena ISO 8601.
+     *
+     * @param  mixed  $value  El valor de tiempo a convertir.
+     * @return mixed La cadena ISO 8601 o el valor original si no se puede convertir.
+     */
+    protected function toAuditTemporalString(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+
+        try {
+            $instant = $value instanceof \DateTimeInterface
+                ? Carbon::instance($value)
+                : Carbon::parse((string) $value);
+            $instant = $instant->utc();
+
+            $tz = config('messaging.audit_timestamp_timezone');
+            if (is_string($tz) && $tz !== '') {
+                try {
+                    return $instant->timezone($tz)->toIso8601String();
+                } catch (\Throwable) {
+                    return $instant->toIso8601ZuluString();
+                }
+            }
+
+            return $instant->toIso8601ZuluString();
+        } catch (\Throwable) {
+            return $value;
+        }
+    }
+}

--- a/backend/app/Observers/ErrorCodeObserver.php
+++ b/backend/app/Observers/ErrorCodeObserver.php
@@ -19,7 +19,7 @@ final class ErrorCodeObserver extends AbstractAuditableModelObserver
 
     protected function resolveAuditUserId(Model $model): string
     {
-        return (string) (auth()->id() ?? 'system');
+        return $this->jwtSubjectFromRequest() ?? 'system';
     }
 
     public function created(ErrorCode $errorCode): void

--- a/backend/app/Observers/ErrorCodeObserver.php
+++ b/backend/app/Observers/ErrorCodeObserver.php
@@ -1,42 +1,39 @@
 <?php
+
 namespace App\Observers;
 
 use App\Models\ErrorCode;
-use Illuminate\Database\Eloquent\Attributes\ObservedBy;
-use Illuminate\Support\Facades\DB;
-use Maya\Messaging\Publishers\AuditPublisher;
+use Illuminate\Database\Eloquent\Model;
 
-class ErrorCodeObserver
+final class ErrorCodeObserver extends AbstractAuditableModelObserver
 {
-    public function __construct(private readonly AuditPublisher $publisher) {}
+    protected function auditEntityType(): string
+    {
+        return 'error_code';
+    }
+
+    protected function auditTemporalKeys(): array
+    {
+        return self::AUDIT_ELOQUENT_TEMPORAL_KEYS;
+    }
+
+    protected function resolveAuditUserId(Model $model): string
+    {
+        return (string) (auth()->id() ?? 'system');
+    }
 
     public function created(ErrorCode $errorCode): void
     {
-        DB::afterCommit(fn () => $this->publish('Creado un Error code', $errorCode, null, $errorCode->getAttributes()));
+        $this->auditAfterCreate('Creado un código de error', $errorCode);
     }
 
     public function updated(ErrorCode $errorCode): void
     {
-        $previous= array_intersect_key($errorCode->getOriginal(), $errorCode->getChanges());
-        DB::afterCommit(fn() => $this->publish('Actualizado un Error code', $errorCode, $previous, $errorCode->getChanges()));
+        $this->auditAfterUpdate('Actualizado un código de error', $errorCode);
     }
 
     public function deleted(ErrorCode $errorCode): void
     {
-        DB::afterCommit(fn() => $this->publish('Eliminado un Error code', $errorCode, $errorCode->getAttributes(), null));
-    }
-
-
-    private function publish(string $action, ErrorCode $errorCode, ?array $previous, ?array $new): void
-    {
-        $this->publisher->publish(
-            applicationSlug: 'maya-logs',
-            entityType: self::ENTITY_TYPE,
-            entityId:  (string) $errorCode->getKey(),
-            action: $action,
-            userId: (string) (auth()->id() ?? 'system'),
-            previousValue:  $previous,
-            newValue:  $new,
-        );
+        $this->auditAfterDelete('Eliminado un código de error', $errorCode);
     }
 }

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -64,7 +64,7 @@ class AppServiceProvider extends ServiceProvider
 
         if (! $this->app->runningUnitTests()) {
             Log::shareContext([
-                'emitting_service' => 'maya_logs',
+                'emitting_service' => (string) config('messaging.app'),
             ]);
         }
     }

--- a/backend/app/Providers/EventServiceProvider.php
+++ b/backend/app/Providers/EventServiceProvider.php
@@ -2,14 +2,20 @@
 
 namespace App\Providers;
 
+use App\Listeners\PublishTelemetryOnAuditPublishFailure;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Log\Events\MessageLogged;
 
 class EventServiceProvider extends ServiceProvider
 {
     /**
      * @var array<class-string, array<int, class-string>>
      */
-    protected $listen = [];
+    protected $listen = [
+        MessageLogged::class => [
+            PublishTelemetryOnAuditPublishFailure::class,
+        ],
+    ];
 
     public function boot(): void
     {

--- a/backend/app/Services/CommentService.php
+++ b/backend/app/Services/CommentService.php
@@ -5,10 +5,12 @@ namespace App\Services;
 use App\Models\Comment;
 use App\Repositories\Contracts\CommentRepositoryInterface;
 use App\Services\Contracts\CommentServiceInterface;
+use App\Support\ResilientLogPublisher;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 use Mews\Purifier\Facades\Purifier;
+use Throwable;
 
 final class CommentService implements CommentServiceInterface
 {
@@ -16,17 +18,41 @@ final class CommentService implements CommentServiceInterface
 
     private const MAX_IMAGE_BYTES = 2 * 1024 * 1024;
 
+    private const CODE_NOT_FOUND = 'LAR-LOG-014';
+
+    private const CODE_CREATE_FAILED = 'LAR-LOG-015';
+
+    private const CODE_UPDATE_FAILED = 'LAR-LOG-016';
+
+    private const CODE_DELETE_FAILED = 'LAR-LOG-017';
+
     public function __construct(
         private readonly CommentRepositoryInterface $commentRepository,
-    ) {
+        private readonly ResilientLogPublisher $resilientLogPublisher,
+    ) {}
+
+    private function messagingAppSlug(): string
+    {
+        return (string) config('messaging.app');
     }
 
     /**
-     * Busca un comentario por su id.
+     * Sin telemetría en listados (evita ruido); solo se publica a maya.logs si falla la carga por id.
      */
     public function findOrFail(int $id): Comment
     {
-        return $this->commentRepository->findOrFail($id);
+        try {
+            return $this->commentRepository->findOrFail($id);
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_NOT_FOUND,
+                ['comment_id' => $id],
+                $this->messagingAppSlug(),
+            );
+            throw $e;
+        }
     }
 
     /**
@@ -44,7 +70,18 @@ final class CommentService implements CommentServiceInterface
     {
         $sanitized = $this->sanitizeAndValidateContent($rawContent);
 
-        return $this->commentRepository->createForCommentable($commentable, $userId, $sanitized);
+        try {
+            return $this->commentRepository->createForCommentable($commentable, $userId, $sanitized);
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_CREATE_FAILED,
+                array_merge($this->commentableMetadata($commentable), ['user_id' => $userId]),
+                $this->messagingAppSlug(),
+            );
+            throw $e;
+        }
     }
 
     /**
@@ -54,7 +91,18 @@ final class CommentService implements CommentServiceInterface
     {
         $sanitized = $this->sanitizeAndValidateContent($rawContent);
 
-        return $this->commentRepository->updateContent($comment, $sanitized);
+        try {
+            return $this->commentRepository->updateContent($comment, $sanitized);
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_UPDATE_FAILED,
+                ['comment_id' => $comment->id],
+                $this->messagingAppSlug(),
+            );
+            throw $e;
+        }
     }
 
     /**
@@ -62,7 +110,29 @@ final class CommentService implements CommentServiceInterface
      */
     public function delete(Comment $comment): void
     {
-        $this->commentRepository->delete($comment);
+        try {
+            $this->commentRepository->delete($comment);
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_DELETE_FAILED,
+                ['comment_id' => $comment->id],
+                $this->messagingAppSlug(),
+            );
+            throw $e;
+        }
+    }
+
+    /**
+     * @return array{commentable_type: string, commentable_id: mixed}
+     */
+    private function commentableMetadata(Model $commentable): array
+    {
+        return [
+            'commentable_type' => $commentable->getMorphClass(),
+            'commentable_id' => $commentable->getKey(),
+        ];
     }
 
     /**
@@ -135,7 +205,7 @@ final class CommentService implements CommentServiceInterface
                 ]);
             }
 
-            if (!$this->isAllowedImageByMagicBytes($decoded)) {
+            if (! $this->isAllowedImageByMagicBytes($decoded)) {
                 throw ValidationException::withMessages([
                     'content' => __('comments.editor.image_invalid_type'),
                 ]);

--- a/backend/app/Services/CommentService.php
+++ b/backend/app/Services/CommentService.php
@@ -4,20 +4,15 @@ namespace App\Services;
 
 use App\Models\Comment;
 use App\Repositories\Contracts\CommentRepositoryInterface;
+use App\Services\Contracts\CommentContentSanitizerInterface;
 use App\Services\Contracts\CommentServiceInterface;
 use App\Support\ResilientLogPublisher;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Validation\ValidationException;
-use Mews\Purifier\Facades\Purifier;
 use Throwable;
 
 final class CommentService implements CommentServiceInterface
 {
-    private const MAX_COMMENT_BYTES = 10 * 1024 * 1024;
-
-    private const MAX_IMAGE_BYTES = 2 * 1024 * 1024;
-
     private const CODE_NOT_FOUND = 'LAR-LOG-014';
 
     private const CODE_CREATE_FAILED = 'LAR-LOG-015';
@@ -29,6 +24,7 @@ final class CommentService implements CommentServiceInterface
     public function __construct(
         private readonly CommentRepositoryInterface $commentRepository,
         private readonly ResilientLogPublisher $resilientLogPublisher,
+        private readonly CommentContentSanitizerInterface $commentContentSanitizer,
     ) {}
 
     private function messagingAppSlug(): string
@@ -68,7 +64,7 @@ final class CommentService implements CommentServiceInterface
      */
     public function createForCommentable(Model $commentable, string $userId, string $rawContent): Comment
     {
-        $sanitized = $this->sanitizeAndValidateContent($rawContent);
+        $sanitized = $this->commentContentSanitizer->sanitize($rawContent);
 
         try {
             return $this->commentRepository->createForCommentable($commentable, $userId, $sanitized);
@@ -89,7 +85,7 @@ final class CommentService implements CommentServiceInterface
      */
     public function updateContent(Comment $comment, string $rawContent): Comment
     {
-        $sanitized = $this->sanitizeAndValidateContent($rawContent);
+        $sanitized = $this->commentContentSanitizer->sanitize($rawContent);
 
         try {
             return $this->commentRepository->updateContent($comment, $sanitized);
@@ -133,105 +129,5 @@ final class CommentService implements CommentServiceInterface
             'commentable_type' => $commentable->getMorphClass(),
             'commentable_id' => $commentable->getKey(),
         ];
-    }
-
-    /**
-     * Sanitiza y valida el contenido de un comentario.
-     */
-    private function sanitizeAndValidateContent(string $rawContent): string
-    {
-        $sanitized = Purifier::clean($rawContent, 'rich_comment');
-
-        $this->validateNotBlank($sanitized);
-        $this->validateContentSize($sanitized);
-        $this->validateEmbeddedImages($sanitized);
-
-        return $sanitized;
-    }
-
-    /**
-     * Valida que el contenido no esté en blanco.
-     */
-    private function validateNotBlank(string $html): void
-    {
-        $textOnly = trim(strip_tags(str_ireplace(['<br>', '<br/>', '<br />'], ' ', $html)));
-
-        if ($textOnly !== '' || str_contains($html, '<img')) {
-            return;
-        }
-
-        throw ValidationException::withMessages([
-            'content' => __('validation.required', ['attribute' => 'content']),
-        ]);
-    }
-
-    /**
-     * Valida que el contenido no sea demasiado grande.
-     */
-    private function validateContentSize(string $html): void
-    {
-        if (strlen($html) <= self::MAX_COMMENT_BYTES) {
-            return;
-        }
-
-        throw ValidationException::withMessages([
-            'content' => __('comments.editor.comment_too_large'),
-        ]);
-    }
-
-    /**
-     * Valida que las imágenes incrustadas no sean demasiado grandes.
-     */
-    private function validateEmbeddedImages(string $html): void
-    {
-        preg_match_all('/<img[^>]+src=["\']([^"\']+)["\']/i', $html, $matches);
-        $sources = $matches[1] ?? [];
-
-        foreach ($sources as $src) {
-            if (preg_match('/^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/s', $src, $parts) !== 1) {
-                continue;
-            }
-
-            $decoded = base64_decode($parts[2], true);
-            if ($decoded === false) {
-                throw ValidationException::withMessages([
-                    'content' => __('comments.editor.image_invalid_type'),
-                ]);
-            }
-
-            if (strlen($decoded) > self::MAX_IMAGE_BYTES) {
-                throw ValidationException::withMessages([
-                    'content' => __('comments.editor.image_too_large'),
-                ]);
-            }
-
-            if (! $this->isAllowedImageByMagicBytes($decoded)) {
-                throw ValidationException::withMessages([
-                    'content' => __('comments.editor.image_invalid_type'),
-                ]);
-            }
-        }
-    }
-
-    /**
-     * Valida que las imágenes incrustadas sean de un tipo permitido.
-     */
-    private function isAllowedImageByMagicBytes(string $binary): bool
-    {
-        $header = substr($binary, 0, 12);
-
-        if (str_starts_with($header, "\x89PNG")) {
-            return true;
-        }
-
-        if (str_starts_with($header, "\xFF\xD8\xFF")) {
-            return true;
-        }
-
-        if (str_starts_with($header, 'GIF8')) {
-            return true;
-        }
-
-        return str_starts_with($header, 'RIFF') && substr($header, 8, 4) === 'WEBP';
     }
 }

--- a/backend/app/Services/ErrorCodeService.php
+++ b/backend/app/Services/ErrorCodeService.php
@@ -5,14 +5,30 @@ namespace App\Services;
 use App\Models\ErrorCode;
 use App\Repositories\Contracts\ErrorCodeRepositoryInterface;
 use App\Services\Contracts\ErrorCodeServiceInterface;
+use App\Support\ResilientLogPublisher;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\DB;
+use Throwable;
 
 class ErrorCodeService implements ErrorCodeServiceInterface
 {
+    private const CODE_NOT_FOUND = 'LAR-LOG-010';
+
+    private const CODE_CREATE_FAILED = 'LAR-LOG-011';
+
+    private const CODE_UPDATE_FAILED = 'LAR-LOG-012';
+
+    private const CODE_DELETE_FAILED = 'LAR-LOG-013';
+
     public function __construct(
-        private ErrorCodeRepositoryInterface $errorCodeRepository
+        private ErrorCodeRepositoryInterface $errorCodeRepository,
+        private ResilientLogPublisher $resilientLogPublisher,
     ) {}
+
+    private function messagingAppSlug(): string
+    {
+        return (string) config('messaging.app');
+    }
 
     public function paginate(int $perPage = 15): LengthAwarePaginator
     {
@@ -27,26 +43,90 @@ class ErrorCodeService implements ErrorCodeServiceInterface
         return $this->errorCodeRepository->searchAndFilter($search, $filterApp, $perPage);
     }
 
+    /**
+     * Sin telemetría en listados (evita ruido); solo se publica a maya.logs si falla la carga por id.
+     */
     public function findOrFail(int $id): ErrorCode
     {
-        return $this->errorCodeRepository->findOrFail($id);
+        try {
+            return $this->errorCodeRepository->findOrFail($id);
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_NOT_FOUND,
+                ['error_code_id' => $id],
+                $this->messagingAppSlug(),
+            );
+            throw $e;
+        }
     }
 
+    /**
+     * Crea un nuevo código de error.
+     *
+     * @param  array<string, mixed>  $data  Los datos del código de error.
+     * @return \App\Models\ErrorCode  El código de error creado.
+     */
     public function create(array $data): ErrorCode
     {
-        return $this->errorCodeRepository->create($data);
+        try {
+            return $this->errorCodeRepository->create($data);
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_CREATE_FAILED,
+                ['payload_keys' => array_keys($data)],
+                $this->messagingAppSlug(),
+            );
+            throw $e;
+        }
     }
 
+    /**
+     * Actualiza un código de error.
+     *
+     * @param  \App\Models\ErrorCode  $errorCode  El código de error que se está actualizando.
+     * @param  array<string, mixed>  $data  Los datos del código de error.
+     * @return \App\Models\ErrorCode  El código de error actualizado.
+     */
     public function update(ErrorCode $errorCode, array $data): ErrorCode
     {
-        return $this->errorCodeRepository->update($errorCode, $data);
+        try {
+            return $this->errorCodeRepository->update($errorCode, $data);
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_UPDATE_FAILED,
+                ['error_code_id' => $errorCode->id],
+                $this->messagingAppSlug(),
+            );
+            throw $e;
+        }
     }
 
+    /**
+     * Elimina un código de error.
+     *
+     * @param  \App\Models\ErrorCode  $errorCode  El código de error que se está eliminando.
+     */
     public function delete(ErrorCode $errorCode): void
     {
-        // Use transaction to ensure data integrity
-        DB::transaction(function () use ($errorCode) {
-            $this->errorCodeRepository->delete($errorCode);
-        });
+        try {
+            DB::transaction(function () use ($errorCode): void {
+                $this->errorCodeRepository->delete($errorCode);
+            });
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_DELETE_FAILED,
+                ['error_code_id' => $errorCode->id],
+                $this->messagingAppSlug(),
+            );
+            throw $e;
+        }
     }
 }

--- a/backend/app/Services/LogService.php
+++ b/backend/app/Services/LogService.php
@@ -6,19 +6,29 @@ use App\Enums\Severity;
 use App\Models\Log;
 use App\Repositories\Contracts\LogRepositoryInterface;
 use App\Services\Contracts\LogServiceInterface;
+use App\Support\ResilientLogPublisher;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Maya\Messaging\Publishers\AuditPublisher;
+use Throwable;
 
 class LogService implements LogServiceInterface
 {
     private const AUDIT_ENTITY_TYPE = 'log';
 
+    private const CODE_MARK_RESOLVED_FAILED = 'LAR-LOG-018';
+
     public function __construct(
         private LogRepositoryInterface $logRepository,
         private AuditPublisher $auditPublisher,
+        private ResilientLogPublisher $resilientLogPublisher,
     ) {}
+
+    private function messagingAppSlug(): string
+    {
+        return (string) config('messaging.app');
+    }
 
     /**
      * Devuelve una página de logs.
@@ -162,27 +172,41 @@ class LogService implements LogServiceInterface
 
     /**
      * Marca el log como resuelto.
+     *
+     * Si el log no existe o falla la persistencia, se publica incidencia a maya.logs antes de relanzar.
+     * Si ya estaba resuelto ({@see LogRepositoryInterface::resolved} devuelve 0), no hay auditoría ni telemetría.
      */
     public function resolved(int $logId, string $actorUserId): void
     {
-        $this->logRepository->findOrFail($logId);
+        try {
+            $this->logRepository->findOrFail($logId);
 
-        $affected = $this->logRepository->resolved($logId);
-        if ($affected < 1) {
-            return;
-        }
+            $affected = $this->logRepository->resolved($logId);
+            if ($affected < 1) {
+                return;
+            }
 
-        $this->afterCommit(function () use ($logId, $actorUserId): void {
-            $this->auditPublisher->publish(
-                applicationSlug: (string) config('messaging.app'),
-                entityType: self::AUDIT_ENTITY_TYPE,
-                entityId: (string) $logId,
-                action: 'Marcar un log como resuelto',
-                userId: $actorUserId,
-                previousValue: ['resolved' => false],
-                newValue: ['resolved' => true],
+            $this->afterCommit(function () use ($logId, $actorUserId): void {
+                $this->auditPublisher->publish(
+                    applicationSlug: $this->messagingAppSlug(),
+                    entityType: self::AUDIT_ENTITY_TYPE,
+                    entityId: (string) $logId,
+                    action: 'Marcar un log como resuelto',
+                    userId: $actorUserId,
+                    previousValue: ['resolved' => false],
+                    newValue: ['resolved' => true],
+                );
+            });
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_MARK_RESOLVED_FAILED,
+                ['log_id' => $logId, 'actor_user_id' => $actorUserId],
+                $this->messagingAppSlug(),
             );
-        });
+            throw $e;
+        }
     }
 
     /**

--- a/backend/app/Services/LogService.php
+++ b/backend/app/Services/LogService.php
@@ -17,6 +17,8 @@ class LogService implements LogServiceInterface
 {
     private const AUDIT_ENTITY_TYPE = 'log';
 
+    private const CODE_NOT_FOUND = 'LAR-LOG-019';
+
     private const CODE_MARK_RESOLVED_FAILED = 'LAR-LOG-018';
 
     public function __construct(
@@ -40,10 +42,23 @@ class LogService implements LogServiceInterface
 
     /**
      * Encuentra un log por su id.
+     *
+     * Sin telemetría en listados; solo se publica a maya.logs si falla la carga por id.
      */
     public function findOrFail(int $id): Log
     {
-        return $this->logRepository->findOrFail($id);
+        try {
+            return $this->logRepository->findOrFail($id);
+        } catch (Throwable $e) {
+            $this->resilientLogPublisher->publishFromThrowable(
+                $e,
+                'medium',
+                self::CODE_NOT_FOUND,
+                ['log_id' => $id],
+                $this->messagingAppSlug(),
+            );
+            throw $e;
+        }
     }
 
     /**

--- a/backend/config/messaging.php
+++ b/backend/config/messaging.php
@@ -11,7 +11,7 @@ return [
     | consumidores que enrutan por application_slug.
     |
     */
-    'app' => env('MAYA_MESSAGING_APP', 'maya_logs'),
+    'app' => env('MAYA_MESSAGING_APP', 'maya-logs'),
 
     /*
     |--------------------------------------------------------------------------

--- a/backend/database/data/mock-error-codes.php
+++ b/backend/database/data/mock-error-codes.php
@@ -456,4 +456,10 @@ return [
         'name' => 'Active log mark resolved failed',
         'description' => 'Fallo al marcar un log activo como resuelto (log inexistente o error de persistencia).',
     ],
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-019',
+        'name' => 'Active log not found',
+        'description' => 'No se encontró el log activo solicitado por id.',
+    ],
 ];

--- a/backend/database/data/mock-error-codes.php
+++ b/backend/database/data/mock-error-codes.php
@@ -462,4 +462,10 @@ return [
         'name' => 'Active log not found',
         'description' => 'No se encontró el log activo solicitado por id.',
     ],
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-020',
+        'name' => 'Audit event publish failed',
+        'description' => 'AuditPublisher no pudo enviar a maya.audit (p. ej. tras marcar resuelto u otro CRUD); RetryAmqpPublishJob puede recuperarlo.',
+    ],
 ];

--- a/backend/database/data/mock-error-codes.php
+++ b/backend/database/data/mock-error-codes.php
@@ -424,4 +424,29 @@ return [
         'name' => 'Error code delete failed',
         'description' => 'Fallo al eliminar un código de error (y comentarios en cascada) desde el panel.',
     ],
+    // Telemetría del panel: comentarios (CommentService)
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-014',
+        'name' => 'Comment not found',
+        'description' => 'No se encontró el comentario solicitado por id.',
+    ],
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-015',
+        'name' => 'Comment create failed',
+        'description' => 'Fallo al persistir un comentario sobre un modelo comentable.',
+    ],
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-016',
+        'name' => 'Comment update failed',
+        'description' => 'Fallo al actualizar el contenido de un comentario.',
+    ],
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-017',
+        'name' => 'Comment delete failed',
+        'description' => 'Fallo al eliminar un comentario.',
+    ],
 ];

--- a/backend/database/data/mock-error-codes.php
+++ b/backend/database/data/mock-error-codes.php
@@ -399,4 +399,29 @@ return [
         'name' => 'Log ingestion: invalid occurred_at',
         'description' => 'Formato de occurred_at no parseable; se sustituye por la hora actual al persistir.',
     ],
+    // Telemetría del panel: CRUD de códigos de error (ErrorCodeService)
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-010',
+        'name' => 'Error code not found',
+        'description' => 'No se encontró el código de error solicitado por id.',
+    ],
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-011',
+        'name' => 'Error code create failed',
+        'description' => 'Fallo al crear un código de error desde el panel.',
+    ],
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-012',
+        'name' => 'Error code update failed',
+        'description' => 'Fallo al actualizar un código de error desde el panel.',
+    ],
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-013',
+        'name' => 'Error code delete failed',
+        'description' => 'Fallo al eliminar un código de error (y comentarios en cascada) desde el panel.',
+    ],
 ];

--- a/backend/database/data/mock-error-codes.php
+++ b/backend/database/data/mock-error-codes.php
@@ -449,4 +449,11 @@ return [
         'name' => 'Comment delete failed',
         'description' => 'Fallo al eliminar un comentario.',
     ],
+    // Telemetría del panel: logs (LogService)
+    [
+        'application_id' => 4,
+        'code' => 'LAR-LOG-018',
+        'name' => 'Active log mark resolved failed',
+        'description' => 'Fallo al marcar un log activo como resuelto (log inexistente o error de persistencia).',
+    ],
 ];

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -28,7 +28,7 @@
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="LOG_CHANNEL" value="null"/>
-        <env name="MAYA_MESSAGING_APP" value="maya_logs"/>
+        <env name="MAYA_MESSAGING_APP" value="maya-logs"/>
         <env name="AUTH_EXTERNAL_URL" value="http://auth.example.com"/>
         <env name="AUTH_EXTERNAL_PUBLIC_URL" value="http://auth.example.com/login"/>
         <env name="MAIL_MAILER" value="array"/>

--- a/backend/tests/Unit/CommentServiceTest.php
+++ b/backend/tests/Unit/CommentServiceTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit;
 use App\Models\Comment;
 use App\Models\ErrorCode;
 use App\Repositories\Contracts\CommentRepositoryInterface;
+use App\Services\CommentContentSanitizer;
 use App\Services\CommentService;
 use App\Support\ResilientLogPublisher;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -18,6 +19,13 @@ use Tests\TestCase;
 
 class CommentServiceTest extends TestCase
 {
+    private function makeSut(
+        CommentRepositoryInterface $repo,
+        ResilientLogPublisher $publisher,
+    ): CommentService {
+        return new CommentService($repo, $publisher, new CommentContentSanitizer);
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();
@@ -45,7 +53,7 @@ class CommentServiceTest extends TestCase
             ->with(7)
             ->andThrow(new ModelNotFoundException);
 
-        $sut = new CommentService($repo, new ResilientLogPublisher($logPublisher));
+        $sut = $this->makeSut($repo, new ResilientLogPublisher($logPublisher));
 
         $this->expectException(ModelNotFoundException::class);
         $sut->findOrFail(7);
@@ -62,7 +70,7 @@ class CommentServiceTest extends TestCase
         $repo->shouldReceive('delete')->once()->with($comment);
 
         $publisher = new ResilientLogPublisher($this->createMock(LogPublisher::class));
-        $sut = new CommentService($repo, $publisher);
+        $sut = $this->makeSut($repo, $publisher);
 
         $sut->delete($comment);
     }
@@ -79,7 +87,7 @@ class CommentServiceTest extends TestCase
         $logPublisher = $this->createMock(LogPublisher::class);
         $logPublisher->expects($this->never())->method('publish');
 
-        $sut = new CommentService($repo, new ResilientLogPublisher($logPublisher));
+        $sut = $this->makeSut($repo, new ResilientLogPublisher($logPublisher));
 
         $this->expectException(ValidationException::class);
         $sut->createForCommentable($commentable, 'user-1', '   ');

--- a/backend/tests/Unit/CommentServiceTest.php
+++ b/backend/tests/Unit/CommentServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\Comment;
+use App\Models\ErrorCode;
+use App\Repositories\Contracts\CommentRepositoryInterface;
+use App\Services\CommentService;
+use App\Support\ResilientLogPublisher;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Validation\ValidationException;
+use Maya\Messaging\Publishers\LogPublisher;
+use Mockery;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use Tests\TestCase;
+
+class CommentServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_find_or_fail_publica_telemetria_si_no_existe(): void
+    {
+        $logPublisher = $this->createMock(LogPublisher::class);
+        $logPublisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'medium',
+                $this->anything(),
+                'LAR-LOG-014',
+                $this->anything(),
+                $this->anything(),
+                ['comment_id' => 7],
+                $this->anything(),
+            );
+
+        $repo = Mockery::mock(CommentRepositoryInterface::class);
+        $repo->shouldReceive('findOrFail')
+            ->once()
+            ->with(7)
+            ->andThrow(new ModelNotFoundException);
+
+        $sut = new CommentService($repo, new ResilientLogPublisher($logPublisher));
+
+        $this->expectException(ModelNotFoundException::class);
+        $sut->findOrFail(7);
+    }
+
+    #[DoesNotPerformAssertions]
+    public function test_delete_delega_en_repositorio_sin_error(): void
+    {
+        $comment = new Comment;
+        $comment->id = 3;
+        $comment->exists = true;
+
+        $repo = Mockery::mock(CommentRepositoryInterface::class);
+        $repo->shouldReceive('delete')->once()->with($comment);
+
+        $publisher = new ResilientLogPublisher($this->createMock(LogPublisher::class));
+        $sut = new CommentService($repo, $publisher);
+
+        $sut->delete($comment);
+    }
+
+    public function test_create_no_publica_si_falla_validacion_de_contenido(): void
+    {
+        $commentable = new ErrorCode;
+        $commentable->id = 1;
+        $commentable->exists = true;
+
+        $repo = Mockery::mock(CommentRepositoryInterface::class);
+        $repo->shouldReceive('createForCommentable')->never();
+
+        $logPublisher = $this->createMock(LogPublisher::class);
+        $logPublisher->expects($this->never())->method('publish');
+
+        $sut = new CommentService($repo, new ResilientLogPublisher($logPublisher));
+
+        $this->expectException(ValidationException::class);
+        $sut->createForCommentable($commentable, 'user-1', '   ');
+    }
+}

--- a/backend/tests/Unit/ErrorCodeObserverTest.php
+++ b/backend/tests/Unit/ErrorCodeObserverTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\ErrorCode;
+use App\Observers\ErrorCodeObserver;
+use Illuminate\Http\Request;
+use Maya\Messaging\Publishers\AuditPublisher;
+use Mockery;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use Tests\TestCase;
+
+class ErrorCodeObserverTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    #[DoesNotPerformAssertions]
+    public function test_created_usa_jwt_subject_como_actor(): void
+    {
+        config(['messaging.app' => 'maya-logs']);
+
+        $request = Request::create('/api/v1/error-codes', 'POST');
+        $request->attributes->set('jwt_user', ['id' => 'jwt-sub-42']);
+        $this->app->instance('request', $request);
+
+        $publisher = Mockery::mock(AuditPublisher::class);
+        $publisher->shouldReceive('publish')
+            ->once()
+            ->withArgs(static function (
+                string $applicationSlug,
+                string $entityType,
+                string $entityId,
+                string $action,
+                string $userId,
+            ): bool {
+                return $applicationSlug === 'maya-logs'
+                    && $entityType === 'error_code'
+                    && $entityId === '5'
+                    && $action === 'Creado un código de error'
+                    && $userId === 'jwt-sub-42';
+            });
+
+        $observer = new ErrorCodeObserver($publisher);
+        $model = new ErrorCode(['code' => 'X', 'application_id' => 1, 'name' => 'X']);
+        $model->id = 5;
+        $model->exists = false;
+        $model->syncOriginal();
+
+        $observer->created($model);
+    }
+
+    #[DoesNotPerformAssertions]
+    public function test_created_usa_system_sin_jwt_en_request(): void
+    {
+        config(['messaging.app' => 'maya-logs']);
+
+        $request = Request::create('/api/v1/error-codes', 'POST');
+        $this->app->instance('request', $request);
+
+        $publisher = Mockery::mock(AuditPublisher::class);
+        $publisher->shouldReceive('publish')
+            ->once()
+            ->withArgs(static function (
+                string $applicationSlug,
+                string $entityType,
+                string $entityId,
+                string $action,
+                string $userId,
+            ): bool {
+                return $applicationSlug === 'maya-logs' && $userId === 'system';
+            });
+
+        $observer = new ErrorCodeObserver($publisher);
+        $model = new ErrorCode(['code' => 'Y', 'application_id' => 1, 'name' => 'Y']);
+        $model->id = 6;
+        $model->exists = false;
+        $model->syncOriginal();
+
+        $observer->created($model);
+    }
+}

--- a/backend/tests/Unit/ErrorCodeServiceTest.php
+++ b/backend/tests/Unit/ErrorCodeServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\ErrorCode;
+use App\Repositories\Contracts\ErrorCodeRepositoryInterface;
+use App\Services\ErrorCodeService;
+use App\Support\ResilientLogPublisher;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Maya\Messaging\Publishers\LogPublisher;
+use Mockery;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use Tests\TestCase;
+
+class ErrorCodeServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_find_or_fail_publica_telemetria_si_no_existe(): void
+    {
+        $logPublisher = $this->createMock(LogPublisher::class);
+        $logPublisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'medium',
+                $this->anything(),
+                'LAR-LOG-010',
+                $this->anything(),
+                $this->anything(),
+                ['error_code_id' => 99],
+                $this->anything(),
+            );
+
+        $repo = Mockery::mock(ErrorCodeRepositoryInterface::class);
+        $repo->shouldReceive('findOrFail')
+            ->once()
+            ->with(99)
+            ->andThrow(new ModelNotFoundException);
+
+        $sut = new ErrorCodeService($repo, new ResilientLogPublisher($logPublisher));
+
+        $this->expectException(ModelNotFoundException::class);
+        $sut->findOrFail(99);
+    }
+
+    #[DoesNotPerformAssertions]
+    public function test_create_delega_en_repositorio_sin_error(): void
+    {
+        $model = new ErrorCode(['code' => 'X', 'application_id' => 1, 'name' => 'X']);
+        $model->id = 1;
+
+        $repo = Mockery::mock(ErrorCodeRepositoryInterface::class);
+        $repo->shouldReceive('create')
+            ->once()
+            ->with(['code' => 'X', 'application_id' => 1])
+            ->andReturn($model);
+
+        $publisher = new ResilientLogPublisher($this->createMock(LogPublisher::class));
+        $sut = new ErrorCodeService($repo, $publisher);
+
+        $sut->create(['code' => 'X', 'application_id' => 1]);
+    }
+}

--- a/backend/tests/Unit/LogServiceFindOrFailTest.php
+++ b/backend/tests/Unit/LogServiceFindOrFailTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Repositories\Contracts\LogRepositoryInterface;
+use App\Services\LogService;
+use App\Support\ResilientLogPublisher;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Maya\Messaging\Publishers\AuditPublisher;
+use Maya\Messaging\Publishers\LogPublisher;
+use Mockery;
+use Tests\TestCase;
+
+class LogServiceFindOrFailTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_find_or_fail_publica_telemetria_si_no_existe(): void
+    {
+        $logPublisher = $this->createMock(LogPublisher::class);
+        $logPublisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'medium',
+                $this->anything(),
+                'LAR-LOG-019',
+                $this->anything(),
+                $this->anything(),
+                ['log_id' => 55],
+                $this->anything(),
+            );
+
+        $repo = Mockery::mock(LogRepositoryInterface::class);
+        $repo->shouldReceive('findOrFail')
+            ->once()
+            ->with(55)
+            ->andThrow(new ModelNotFoundException);
+
+        $sut = new LogService(
+            $repo,
+            $this->createMock(AuditPublisher::class),
+            new ResilientLogPublisher($logPublisher),
+        );
+
+        $this->expectException(ModelNotFoundException::class);
+        $sut->findOrFail(55);
+    }
+}

--- a/backend/tests/Unit/LogServiceResolvedTest.php
+++ b/backend/tests/Unit/LogServiceResolvedTest.php
@@ -5,7 +5,10 @@ namespace Tests\Unit;
 use App\Models\Log;
 use App\Repositories\Contracts\LogRepositoryInterface;
 use App\Services\LogService;
+use App\Support\ResilientLogPublisher;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Maya\Messaging\Publishers\AuditPublisher;
+use Maya\Messaging\Publishers\LogPublisher;
 use Tests\TestCase;
 
 class LogServiceResolvedTest extends TestCase
@@ -28,7 +31,9 @@ class LogServiceResolvedTest extends TestCase
         $publisher->expects($this->once())
             ->method('publish');
 
-        $service = new LogService($repository, $publisher);
+        $resilient = new ResilientLogPublisher($this->createMock(LogPublisher::class));
+
+        $service = new LogService($repository, $publisher, $resilient);
         $service->resolved(42, 'sub-1');
     }
 
@@ -50,7 +55,44 @@ class LogServiceResolvedTest extends TestCase
         $publisher->expects($this->never())
             ->method('publish');
 
-        $service = new LogService($repository, $publisher);
+        $resilient = new ResilientLogPublisher($this->createMock(LogPublisher::class));
+
+        $service = new LogService($repository, $publisher, $resilient);
         $service->resolved(7, 'sub-2');
+    }
+
+    public function test_resolved_publica_telemetria_si_el_log_no_existe(): void
+    {
+        $repository = $this->createMock(LogRepositoryInterface::class);
+        $repository->expects($this->once())
+            ->method('findOrFail')
+            ->with(99)
+            ->willThrowException(new ModelNotFoundException);
+        $repository->expects($this->never())->method('resolved');
+
+        $logPublisher = $this->createMock(LogPublisher::class);
+        $logPublisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'medium',
+                $this->anything(),
+                'LAR-LOG-018',
+                $this->anything(),
+                $this->anything(),
+                ['log_id' => 99, 'actor_user_id' => 'sub-x'],
+                $this->anything(),
+            );
+
+        $audit = $this->createMock(AuditPublisher::class);
+        $audit->expects($this->never())->method('publish');
+
+        $service = new LogService(
+            $repository,
+            $audit,
+            new ResilientLogPublisher($logPublisher),
+        );
+
+        $this->expectException(ModelNotFoundException::class);
+        $service->resolved(99, 'sub-x');
     }
 }

--- a/backend/tests/Unit/NormalizesAuditTemporalPayloadTest.php
+++ b/backend/tests/Unit/NormalizesAuditTemporalPayloadTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Observers\Concerns\NormalizesAuditTemporalPayload;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class NormalizesAuditTemporalPayloadTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_formats_eloquent_timestamps_in_configured_timezone(): void
+    {
+        config(['messaging.audit_timestamp_timezone' => 'Europe/Madrid']);
+        Carbon::setTestNow(Carbon::parse('2026-05-15T08:20:47Z'));
+
+        $normalizer = new class
+        {
+            use NormalizesAuditTemporalPayload;
+
+            /** @param  list<string>  $keys */
+            public function normalize(?array $payload, array $keys): ?array
+            {
+                return $this->normalizeAuditTemporalPayload($payload, $keys);
+            }
+        };
+
+        $result = $normalizer->normalize(
+            ['created_at' => '2026-05-15 08:20:47', 'content' => 'x'],
+            ['created_at', 'updated_at'],
+        );
+
+        $this->assertSame('x', $result['content']);
+        $this->assertStringContainsString('2026-05-15T10:20:47', (string) $result['created_at']);
+        $this->assertStringContainsString('+', (string) $result['created_at']);
+    }
+
+    public function test_falls_back_to_utc_z_when_timezone_config_empty(): void
+    {
+        config(['messaging.audit_timestamp_timezone' => '']);
+        Carbon::setTestNow(Carbon::parse('2026-05-15T08:20:47Z'));
+
+        $normalizer = new class
+        {
+            use NormalizesAuditTemporalPayload;
+
+            public function normalize(?array $payload): ?array
+            {
+                return $this->normalizeAuditTemporalPayload($payload, ['created_at']);
+            }
+        };
+
+        $result = $normalizer->normalize(['created_at' => '2026-05-15 08:20:47']);
+
+        $this->assertSame('2026-05-15T08:20:47Z', $result['created_at']);
+    }
+}

--- a/backend/tests/Unit/PublishTelemetryOnAuditPublishFailureTest.php
+++ b/backend/tests/Unit/PublishTelemetryOnAuditPublishFailureTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Listeners\PublishTelemetryOnAuditPublishFailure;
+use App\Support\ResilientLogPublisher;
+use Illuminate\Log\Events\MessageLogged;
+use Maya\Messaging\Publishers\LogPublisher;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PublishTelemetryOnAuditPublishFailureTest extends TestCase
+{
+    #[Test]
+    public function publica_lar_log_020_en_audit_publish_failed(): void
+    {
+        config(['messaging.app' => 'maya-logs']);
+
+        $logPublisher = $this->createMock(LogPublisher::class);
+        $logPublisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'high',
+                'broker down',
+                'LAR-LOG-020',
+                $this->anything(),
+                $this->anything(),
+                [
+                    'exchange' => 'maya.audit',
+                    'application_slug' => 'maya-logs',
+                    'entity_type' => 'log',
+                    'entity_id' => '42',
+                    'action' => 'Marcar un log como resuelto',
+                    'user_id' => 'sub-1',
+                ],
+                'maya-logs',
+            );
+
+        $listener = new PublishTelemetryOnAuditPublishFailure(
+            new ResilientLogPublisher($logPublisher),
+        );
+
+        $listener->handle(new MessageLogged('warning', 'audit.publish_failed', [
+            'exchange' => 'maya.audit',
+            'application_slug' => 'maya-logs',
+            'entity_type' => 'log',
+            'entity_id' => '42',
+            'action' => 'Marcar un log como resuelto',
+            'user_id' => 'sub-1',
+            'error' => 'broker down',
+        ]));
+    }
+
+    #[Test]
+    public function ignora_otros_mensajes_de_log(): void
+    {
+        $logPublisher = $this->createMock(LogPublisher::class);
+        $logPublisher->expects($this->never())->method('publish');
+
+        $listener = new PublishTelemetryOnAuditPublishFailure(
+            new ResilientLogPublisher($logPublisher),
+        );
+
+        $listener->handle(new MessageLogged('warning', 'other.message', []));
+        $listener->handle(new MessageLogged('error', 'audit.publish_failed', []));
+    }
+}

--- a/backend/tests/Unit/ResilientLogPublisherTest.php
+++ b/backend/tests/Unit/ResilientLogPublisherTest.php
@@ -32,12 +32,12 @@ class ResilientLogPublisherTest extends TestCase
         $original = new RuntimeException('error de negocio');
 
         $sut = new ResilientLogPublisher($logPublisher);
-        $sut->publishFromThrowable($original, 'medium', 'test_error_code', ['k' => 1], 'maya_logs');
+        $sut->publishFromThrowable($original, 'medium', 'test_error_code', ['k' => 1], 'maya-logs');
 
         Event::assertDispatched(MessageLogged::class, function (MessageLogged $event): bool {
             return $event->level === 'warning'
                 && $event->message === 'maya.logs.publish_failed_after_operation_failure'
-                && ($event->context['app'] ?? null) === 'maya_logs'
+                && ($event->context['app'] ?? null) === 'maya-logs'
                 && ($event->context['error_code'] ?? null) === 'test_error_code'
                 && ($event->context['original_message'] ?? null) === 'error de negocio'
                 && ($event->context['publish_error'] ?? null) === 'broker caído';
@@ -72,7 +72,7 @@ class ResilientLogPublisherTest extends TestCase
             ->willThrowException(new RuntimeException('broker down'));
 
         $sut = new ResilientLogPublisher($logPublisher);
-        $sut->publishStructured('low', 'mensaje', 'LAR-LOG-099', ['k' => 1], 'maya_logs');
+        $sut->publishStructured('low', 'mensaje', 'LAR-LOG-099', ['k' => 1], 'maya-logs');
 
         Event::assertDispatched(MessageLogged::class, function (MessageLogged $event): bool {
             return $event->level === 'warning'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       RABBITMQ_USER: ${RABBITMQ_USER:-admin}
       RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-admin}
       RABBITMQ_VHOST: ${RABBITMQ_VHOST:-/}
-      MAYA_MESSAGING_APP: maya_logs
+      MAYA_MESSAGING_APP: maya-logs
       # ─── JWT / JWKS ───────────────────────────────────────────
       JWKS_URL: ${JWKS_URL:-http://maya_auth_keycloak:8080/realms/maya/protocol/openid-connect/certs}
       JWT_AUDIENCE: ${JWT_AUDIENCE:-maya-logs}
@@ -104,7 +104,7 @@ services:
       RABBITMQ_USER: ${RABBITMQ_USER:-admin}
       RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-admin}
       RABBITMQ_VHOST: ${RABBITMQ_VHOST:-/}
-      MAYA_MESSAGING_APP: maya_logs
+      MAYA_MESSAGING_APP: maya-logs
       # ─── Logging ────────────────────────────────────────────────
       # IMPORTANTE: el worker NO debe publicar a 'rabbit' — consumiría sus
       # propios logs desde logs.ingest, generando un loop infinito.


### PR DESCRIPTION
Unifica la trazabilidad de maya_logs en dos vías: auditoría (maya.audit vía observers y acción manual al marcar resuelto) y telemetría operativa (maya.logs con códigos LAR-LOG-001…020 en fallos del panel, ingesta y publicación de audit).

Incluye base común de observers con fechas en zona configurada, slug de aplicación maya-logs alineado con maya_auth, y actor JWT correcto en auditoría de códigos de error.